### PR TITLE
Add MathJax support to the documentation and the repo address

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # ValidatedNumerics.jl #
 
+![Build status](https://travis-ci.org/dpsanders/ValidatedNumerics.jl.svg?branch=master)
+[![Coverage Status](https://coveralls.io/repos/dpsanders/ValidatedNumerics.jl/badge.svg?branch=master)](https://coveralls.io/r/dpsanders/ValidatedNumerics.jl?branch=master)
+
 `ValidatedNumerics.jl` is a Julia package for performing *Validated Numerics* in Julia, i.e. *rigorous* computations with finite-precision floating-point arithmetic.
 
 ![Build status](https://travis-ci.org/dpsanders/ValidatedNumerics.jl.svg?branch=master)
@@ -30,7 +33,8 @@ Documentation is available [**here**](http://dpsanders.github.io/ValidatedNumeri
 - [Intervals.jl](https://github.com/andrioni/Intervals.jl), an alternative implementation of basic interval functions.
 
 ## Authors
-- Luis Benet, Instituto de Ciencias Físicas, Universidad Nacional Autónoma de México (UNAM)
+- [Luis Benet](http://www.cicc.unam.mx/~benet/), Instituto de Ciencias Físicas,
+Universidad Nacional Autónoma de México (UNAM)
 - [David P. Sanders](http://sistemas.fciencias.unam.mx/~dsanders),
 Departamento de Física, Facultad de Ciencias, Universidad Nacional Autónoma de México (UNAM)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,7 +19,7 @@ The aim of the package is correctness over speed, although performance considera
 - [Rounding](rounding.md)
 
 
-## Bibliography 
+## Bibliography
 
 - *Validated Numerics: A Short Introduction to Rigorous Computations*, W. Tucker, Princeton University Press (2010)
 - *Introduction to Interval Analysis*, R.E. Moore, R.B. Kearfott & M.J. Cloud, SIAM (2009)
@@ -28,8 +28,9 @@ The aim of the package is correctness over speed, although performance considera
 - [MPFI.jl](https://github.com/andrioni/MPFI.jl), a Julia wrapper around the [MPFI C library](http://perso.ens-lyon.fr/nathalie.revol/software.html), a multiple-precision interval arithmetic library based on MPFR
 - [Intervals.jl](https://github.com/andrioni/Intervals.jl), an alternative implementation of basic interval functions.
 
-## Authors 
-- Luis Benet, Instituto de Ciencias Físicas, Universidad Nacional Autónoma de México (UNAM)
+## Authors
+- [Luis Benet](http://www.cicc.unam.mx/~benet/), Instituto de Ciencias Físicas,
+Universidad Nacional Autónoma de México (UNAM)
 - [David P. Sanders](http://sistemas.fciencias.unam.mx/~dsanders),
 Departamento de Física, Facultad de Ciencias, Universidad Nacional Autónoma de México (UNAM)
 

--- a/docs/root_finding.md
+++ b/docs/root_finding.md
@@ -1,18 +1,41 @@
+<script type="text/x-mathjax-config">
+  MathJax.Hub.Config({
+    TeX: { equationNumbers: { autoNumber: "AMS" } }
+  });
+  MathJax.Hub.Config({
+    TeX: { extensions: ["AMSmath.js", "AMSsymbols.js", "autobold.js", "autoload-all.js"] }
+  });
+  MathJax.Hub.Config({
+    tex2jax: {
+      inlineMath: [['$','$'], ['\\(','\\)']],
+      processEscapes: true
+    }
+  });
+</script>
+<script type="text/javascript" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML">
+</script>
+
 # Root finding
 
-Interval arithmetic not only provides guaranteed numerical calculations; it also makes possible fundamentally new algorithms.
+Interval arithmetic not only provides guaranteed numerical calculations; it also
+makes possible fundamentally new algorithms.
 
-One such algorithm is the **interval Newton method**. This is a version of the standard Newton (or Newton--Raphson) algorithm for finding roots of equations. The interval version, however, is fundamentally different from its standard counterpart, in that it can (under the best circumstances) provide rigorous *guarantees* about the presence or absence and uniqueness of roots of a given function in a given interval.
+One such algorithm is the **interval Newton method**. This is a version of the
+standard Newton (or Newton-Raphson) algorithm for finding roots of equations.
+The interval version, however, is fundamentally different from its standard
+counterpart, in that it can (under the best circumstances) provide rigorous
+*guarantees* about the presence or absence and uniqueness of roots of a given
+function in a given interval.
 
-The idea of the Newton method is to calculate a root $x^*$ of a function $f$ [i.e., a value such that $f(x^*) = 0$] from an initial guess $x$ using
+The idea of the Newton method is to calculate a root $x^\ast$ of a function $f$ [i.e., a value such that $f(x^*) = 0$] from an initial guess $x$ using
 
 $$x^* = x - \frac{f(x)}{f'(\xi)},$$
 
-for some $\xi$ between $x$ and $xˆ*$. Since $\xi$ is unknown, we can bound it as
+for some $\xi$ between $x$ and $x^*$. Since $\xi$ is unknown, we can bound it as
 
 $$f'(\xi) \in F'(X),$$
 
-where $X$ is a containing interval and $F'(X)$ denotes the **interval extension** of the function $f$, consisting of applying the same operations as the function $f$ to the interval $X$. 
+where $X$ is a containing interval and $F'(X)$ denotes the **interval extension** of the function $f$, consisting of applying the same operations as the function $f$ to the interval $X$.
 
 This allows us to create an interval Newton operator that acts on an interval and tells us *rigorously*  if there is a unique root or no root in the interval. There is also an extension to intervals in which the derivative $F'(X)$ contains $0$.
 
@@ -56,7 +79,7 @@ An interface `find_roots` is provided, which does not require an interval to be 
 julia> find_roots(g, -5, 5)
 8-element Array{Tuple{ValidatedNumerics.Interval{Float64},Symbol},1}:
  ([-1.4142135623730951, -1.414213562373095],:unique)
- ([1.4142135623730947, 1.4142135623730954],:unique) 
+ ([1.4142135623730947, 1.4142135623730954],:unique)
  ([1.9999999953782792, 1.9999999967603888],:unknown)
  ([1.9999999967603888, 1.9999999981424985],:unknown)
  ([1.9999999981806982, 1.9999999987913273],:unknown)
@@ -64,5 +87,3 @@ julia> find_roots(g, -5, 5)
  ([1.999999999589721, 2.000000000202166],:unknown)  
  ([2.000000000299439, 2.000000000876634],:unknown)  
 ```
-
- 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,12 +1,29 @@
+<script type="text/x-mathjax-config">
+  MathJax.Hub.Config({
+    TeX: { equationNumbers: { autoNumber: "AMS" } }
+  });
+  MathJax.Hub.Config({
+    TeX: { extensions: ["AMSmath.js", "AMSsymbols.js", "autobold.js", "autoload-all.js"] }
+  });
+  MathJax.Hub.Config({
+    tex2jax: {
+      inlineMath: [['$','$'], ['\\(','\\)']],
+      processEscapes: true
+    }
+  });
+</script>
+<script type="text/javascript" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML">
+</script>
+
 # Basic usage
 
-The basic elements of the package are **intervals**, i.e. sets of real numbers (possibly including $\pm \infty$) of the form 
+The basic elements of the package are **intervals**, i.e. sets of real numbers (possibly including $\pm \infty$) of the form
 
 $$[a, b] := \{ a \le x \le b \} \subseteq \mathbb{R}.$$
 
 ## Creating intervals
 Intervals are created using the `@interval` macro, which takes one or two expressions:
-```julia 
+```julia
 julia> using ValidatedNumerics
 
 julia> a = @interval(1)
@@ -61,7 +78,7 @@ julia> f(@interval(0.1))
 ```
 
 ### $\pi$
-You can create correctly-rounded intervals containing $\pi$: 
+You can create correctly-rounded intervals containing $\pi$:
 ```julia
 julia> @interval(pi)
 [3.141592653589793, 3.1415926535897936]

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,8 @@
-site_name: "ValidatedNumerics.jl: A Julia package for rigorous numerics"
+site_name: ValidatedNumerics.jl
+
+site_description: [ValidatedNumerics.jl: A Julia package for rigorous numerics]
+
+repo_url: https://github.com/dpsanders/ValidatedNumerics.jl
 
 pages:
     - [index.md, Validated Numerics package]
@@ -10,4 +14,4 @@ theme: readthedocs
 
 #markdown_extensions: [math]
 
-
+copyright: Copyright &copy; 2014, 2015, Luis Benet and David P. Sanders


### PR DESCRIPTION
I also included my web page in README.md and included travis and coveralls
badges. Incidentally, the latter was pointing to interval_parameters branch;
the current points to the master branch

In docs/root_finding.md I had to use \ast instead of * to make MathJax
understanding that the asterix was not meant as italics but as an asterix.