### PR TITLE
Adds zero(::Type{Interval}) and one(::Type{Interval}), and tests

### DIFF
--- a/src/intervals/arithmetic.jl
+++ b/src/intervals/arithmetic.jl
@@ -44,7 +44,9 @@ in(x::Real, a::Interval) = a.lo <= x <= a.hi
 ## zero and one functions
 
 zero{T}(a::Interval{T}) = Interval(zero(T))
+zero{T}(::Type{Interval{T}}) = Interval(zero(T))
 one{T}(a::Interval{T}) = Interval(one(T))
+one{T}(::Type{Interval{T}}) = Interval(one(T))
 
 
 ## Addition and subtraction

--- a/test/interval_tests/consistency_tests.jl
+++ b/test/interval_tests/consistency_tests.jl
@@ -14,7 +14,9 @@ facts("Consistency tests") do
     @fact isa( zero(b), Interval ) --> true
 
     @fact zero(b) --> 0.0
+    @fact zero(b) == zero(typeof(b)) --> true
     @fact one(a) --> 1.0
+    @fact one(a) == one(typeof(a)) --> true
     @fact one(a) --> big(1.0)
     @fact a == b --> false
     @fact a != b --> true

--- a/test/root_finding_tests/root_finding_tests.jl
+++ b/test/root_finding_tests/root_finding_tests.jl
@@ -30,8 +30,6 @@ big_pi = @interval(pi)
 set_interval_precision(Float64)
 float_pi = @interval(pi)
 
-Base.⊆(a::Interval, b::Root) = a ⊆ b.interval   # the Root object has the interval in the first entry
-Base.⊆(a::Root, b::Root) = a.interval ⊆ b.interval
 
 # Using precision "only" 256 leads to overestimation of the true roots for `cos`
 # i.e the Newton method gives more accurate results!


### PR DESCRIPTION
The reason to add these methods is to keep up with the usage of zero/one
in Base, and because it is useful to play smoothly with TaylorSeries.
It also deletes two methods of ⊆, which are already in the package,
which were left in root_finding_tests.jl