### PR TITLE
Clean up functions to use CRlibm syntax

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -35,7 +35,7 @@ v0.1 is the first public release of the package.
 ### Interval arithmetic
 - Two methods for interval rounding are available:
  (i) narrow/slow (which uses hardward rounding mode changes for `Float64` intervals, and (ii) wide/fast (which does not change the rounding mode)
-- The current interval precision and rounding mode are stored in the `interval_parameters` object
+- The current interval precision and rounding mode are stored in the `parameters` object
 - The macro `@interval` generates intervals based on the current interval precision
 - Trigonometric functions are "nearly" rigorous (for `Float64` intervals, correct rounding is not currently guaranteed)
 - Inverse trigonometric functions are available

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,5 @@
 julia 0.4
 FactCheck 0.3
 Polynomials
-CRlibm
+CRlibm 0.2.1
+

--- a/src/ValidatedNumerics.jl
+++ b/src/ValidatedNumerics.jl
@@ -1,11 +1,8 @@
 # This file is part of the ValidatedNumerics.jl package; MIT licensed
 
-VERSION >= v"0.4.0-dev+6521" && __precompile__(true)
+#__precompile__(true)
 
 module ValidatedNumerics
-
-
-(VERSION < v"0.4-") && using Docile
 
 using Compat
 #using FactCheck

--- a/src/ValidatedNumerics.jl
+++ b/src/ValidatedNumerics.jl
@@ -41,7 +41,7 @@ export
     widen, infimum, supremum,
     set_interval_precision, get_interval_precision,
     with_interval_precision,
-    interval_parameters, eps, dist, roughly,
+    parameters, eps, dist, roughly,
     pi_interval,
     midpoint_radius, interval_from_midpoint_radius,
     RoundTiesToEven, RoundTiesToAway,

--- a/src/intervals/arithmetic.jl
+++ b/src/intervals/arithmetic.jl
@@ -8,7 +8,7 @@ function in{T<:Real}(x::T, a::Interval)
 end
 
 
-## Comparison of interval_parameters
+## Comparison of parameters
 ## Equalities and neg-equalities
 function ==(a::Interval, b::Interval)
     isempty(a) && isempty(b) && return true

--- a/src/intervals/arithmetic.jl
+++ b/src/intervals/arithmetic.jl
@@ -305,7 +305,7 @@ const RoundTiesToEven = RoundNearest
 # RoundTiesToAway is an alias of `RoundNearestTiesAway`
 const RoundTiesToAway = RoundNearestTiesAway
 
-@doc """
+ """
 .. round(a::Interval, ::RoundingMode)
 
 Returns the interval with rounded limits. It is implemented using Julia's
@@ -347,7 +347,7 @@ function radius(a::Interval)
 end
 
 # cancelplus and cancelminus
-@doc doc"""
+ doc"""
 `cancelminus(a, b)` returns the unique interval `c` such that `b+c=a`.""" ->
 function cancelminus(a::Interval, b::Interval)
     T = promote_type(eltype(a), eltype(b))
@@ -371,7 +371,7 @@ function cancelminus(a::Interval, b::Interval)
     @round(T, a.lo - b.lo, a.hi - b.hi)
 end
 
-@doc doc"""
+ doc"""
 `cancelplus(a, b)` returns the unique interval `c` such that `b-c=a`;
 it is equivalent to `cancelminus(a, −b)`.""" ->
 cancelplus(a::Interval, b::Interval) = cancelminus(a, -b)

--- a/src/intervals/arithmetic.jl
+++ b/src/intervals/arithmetic.jl
@@ -80,13 +80,14 @@ one{T<:Real}(::Type{Interval{T}}) = Interval(one(T))
 
 ## Addition and subtraction
 
++(a::Interval) = a
+-(a::Interval) = Interval(-a.hi, -a.lo)
+
 function +{T<:Real}(a::Interval{T}, b::Interval{T})
     (isempty(a) || isempty(b)) && return emptyinterval(T)
     @round(T, a.lo + b.lo, a.hi + b.hi)
 end
-+(a::Interval) = a
 
--(a::Interval) = Interval(-a.hi, -a.lo)
 function -{T<:Real}(a::Interval{T}, b::Interval{T})
     (isempty(a) || isempty(b)) && return emptyinterval(T)
     @round(T, a.lo - b.hi, a.hi - b.lo)
@@ -103,11 +104,11 @@ function *{T<:Real}(a::Interval{T}, b::Interval{T})
     if b.lo >= zero(T)
         a.lo >= zero(T) && return @round(T, a.lo*b.lo, a.hi*b.hi)
         a.hi <= zero(T) && return @round(T, a.lo*b.hi, a.hi*b.lo)
-        return @round(T, a.lo*b.hi, a.hi*b.hi) # in(zero(T), a)
+        return @round(T, a.lo*b.hi, a.hi*b.hi)   # zero(T) ∈ a
     elseif b.hi <= zero(T)
         a.lo >= zero(T) && return @round(T, a.hi*b.lo, a.lo*b.hi)
         a.hi <= zero(T) && return @round(T, a.hi*b.hi, a.lo*b.lo)
-        return @round(T, a.hi*b.lo, a.lo*b.lo) # in(zero(T), a)
+        return @round(T, a.hi*b.lo, a.lo*b.lo)   # zero(T) ∈ a
     else
         a.lo > zero(T) && return @round(T, a.hi*b.lo, a.hi*b.hi)
         a.hi < zero(T) && return @round(T, a.lo*b.hi, a.lo*b.lo)
@@ -121,7 +122,7 @@ end
 function inv{T<:Real}(a::Interval{T})
     isempty(a) && return emptyinterval(a)
 
-    if in(zero(T), a)
+    if zero(T) ∈ a
         a.lo < zero(T) == a.hi && return @round(T, -Inf, inv(a.lo))
         a.lo == zero(T) < a.hi && return @round(T, inv(a.hi), Inf)
         a.lo < zero(T) < a.hi && return entireinterval(T)
@@ -133,7 +134,7 @@ end
 
 function /{T<:Real}(a::Interval{T}, b::Interval{T})
 
-    S = typeof(a.lo/b.lo)
+    S = typeof(a.lo / b.lo)
     (isempty(a) || isempty(b)) && return emptyinterval(S)
     b == zero(b) && return emptyinterval(S)
 
@@ -141,13 +142,13 @@ function /{T<:Real}(a::Interval{T}, b::Interval{T})
 
         a.lo >= zero(T) && return @round(S, a.lo/b.hi, a.hi/b.lo)
         a.hi <= zero(T) && return @round(S, a.lo/b.lo, a.hi/b.hi)
-        return @round(S, a.lo/b.lo, a.hi/b.lo) # in(zero(T), a)
+        return @round(S, a.lo/b.lo, a.hi/b.lo)  # zero(T) ∈ a
 
     elseif b.hi < zero(T) # b strictly negative
 
         a.lo >= zero(T) && return @round(S, a.hi/b.hi, a.lo/b.lo)
         a.hi <= zero(T) && return @round(S, a.hi/b.lo, a.lo/b.hi)
-        return @round(S, a.hi/b.hi, a.lo/b.hi) # in(zero(T), a)
+        return @round(S, a.hi/b.hi, a.lo/b.hi)  # zero(T) ∈ a
 
     else   # b contains zero, but is not zero(b)
 
@@ -306,13 +307,12 @@ const RoundTiesToEven = RoundNearest
 # RoundTiesToAway is an alias of `RoundNearestTiesAway`
 const RoundTiesToAway = RoundNearestTiesAway
 
- """
-.. round(a::Interval, ::RoundingMode)
+doc"""
+    round(a::Interval, RoundingMode)
 
-Returns the interval with rounded limits. It is implemented using Julia's
-capabilities for controlling the rounding mode.
+Returns the interval with rounded limits.
 
-For compliance with the standard IEEE-1788, "roundTiesToEven" corresponds
+For compliance with the IEEE Std 1788-2015, "roundTiesToEven" corresponds
 to `round(a)` or `round(a, RoundTiesToEven)`, and "roundTiesToAway"
 to `round(a, RoundTiesToAway)`.
 """
@@ -320,10 +320,12 @@ round(a::Interval) = round(a, RoundNearest)
 round(a::Interval, ::RoundingMode{:ToZero}) = trunc(a)
 round(a::Interval, ::RoundingMode{:Up}) = ceil(a)
 round(a::Interval, ::RoundingMode{:Down}) = floor(a)
+
 function round(a::Interval, ::RoundingMode{:Nearest})
     isempty(a) && return emptyinterval(a)
     Interval(round(a.lo), round(a.hi))
 end
+
 function round(a::Interval, ::RoundingMode{:NearestTiesAway})
     isempty(a) && return emptyinterval(a)
     Interval(round(a.lo, RoundNearestTiesAway), round(a.hi, RoundNearestTiesAway))
@@ -344,12 +346,11 @@ end
 function radius(a::Interval)
     isempty(a) && return convert(eltype(a), NaN)
     m = mid(a)
-    max(m-a.lo, a.hi-m)
+    max(m - a.lo, a.hi - m)
 end
 
 # cancelplus and cancelminus
- doc"""
-`cancelminus(a, b)` returns the unique interval `c` such that `b+c=a`."""
+doc"`cancelminus(a, b)` returns the unique interval `c` such that `b+c=a`."
 function cancelminus(a::Interval, b::Interval)
     T = promote_type(eltype(a), eltype(b))
 
@@ -372,9 +373,8 @@ function cancelminus(a::Interval, b::Interval)
     @round(T, a.lo - b.lo, a.hi - b.hi)
 end
 
- doc"""
-`cancelplus(a, b)` returns the unique interval `c` such that `b-c=a`;
-it is equivalent to `cancelminus(a, −b)`."""
+ doc"`cancelplus(a, b)` returns the unique interval `c` such that `b-c=a`;
+it is equivalent to `cancelminus(a, −b)`."
 cancelplus(a::Interval, b::Interval) = cancelminus(a, -b)
 
 

--- a/src/intervals/arithmetic.jl
+++ b/src/intervals/arithmetic.jl
@@ -314,7 +314,7 @@ capabilities for controlling the rounding mode.
 For compliance with the standard IEEE-1788, "roundTiesToEven" corresponds
 to `round(a)` or `round(a, RoundTiesToEven)`, and "roundTiesToAway"
 to `round(a, RoundTiesToAway)`.
-""" ->
+"""
 round(a::Interval) = round(a, RoundNearest)
 round(a::Interval, ::RoundingMode{:ToZero}) = trunc(a)
 round(a::Interval, ::RoundingMode{:Up}) = ceil(a)
@@ -348,7 +348,7 @@ end
 
 # cancelplus and cancelminus
  doc"""
-`cancelminus(a, b)` returns the unique interval `c` such that `b+c=a`.""" ->
+`cancelminus(a, b)` returns the unique interval `c` such that `b+c=a`."""
 function cancelminus(a::Interval, b::Interval)
     T = promote_type(eltype(a), eltype(b))
 
@@ -373,7 +373,7 @@ end
 
  doc"""
 `cancelplus(a, b)` returns the unique interval `c` such that `b-c=a`;
-it is equivalent to `cancelminus(a, −b)`.""" ->
+it is equivalent to `cancelminus(a, −b)`."""
 cancelplus(a::Interval, b::Interval) = cancelminus(a, -b)
 
 

--- a/src/intervals/arithmetic.jl
+++ b/src/intervals/arithmetic.jl
@@ -1,22 +1,23 @@
 # This file is part of the ValidatedNumerics.jl package; MIT licensed
 
-## in, \in, corresponds to isMember
+doc"""`in(x, a::Interval)` (also written ∈, obtained with `\in<TAB>`). [corresponds to `isMember`] checks if the number `x` is a member of the interval `a`, treated as a set."""
 function in{T<:Real}(x::T, a::Interval)
     isinf(x) && return false
-    # isentire(a) && return true
     a.lo <= x <= a.hi
 end
 
 
-## Comparison of parameters
-## Equalities and neg-equalities
+## Comparisons
+
+doc"`a == b` checks if the intervals `a` and `b` are equal."
 function ==(a::Interval, b::Interval)
     isempty(a) && isempty(b) && return true
     a.lo == b.lo && a.hi == b.hi
 end
 !=(a::Interval, b::Interval) = !(a==b)
 
-# issubset, \subseteq
+doc"`a ⊆ b` (written `\subseteq<TAB>`) checks if the interval `a` is a subset
+of the interval `b`."
 function ⊆(a::Interval, b::Interval)
     isempty(a) && return true
     b.lo ≤ a.lo && a.hi ≤ b.hi

--- a/src/intervals/conversion_promotion.jl
+++ b/src/intervals/conversion_promotion.jl
@@ -3,18 +3,19 @@
 ## Conversion and promotion
 
 ## Default conversion to Interval, corresponds to Interval{Float64}
+# do we really need this?
 convert{T<:Real}(::Type{Interval}, x::T) = make_interval(Float64, x)
 
 ## Conversion to specific type intervals
-convert{T<:Union{Float64,BigFloat}}(::Type{Interval{T}}, x::Real) =
-    make_interval(T,x)
-convert{T<:Integer}(::Type{Interval{Rational{T}}}, x::Real) =
-    make_interval(Rational{T}, x)
+convert{T<:Real}(::Type{Interval{T}}, x::Real) = make_interval(T, x)
+
 
 ## Promotion rules
 promote_rule{T<:Real, S<:Real}(::Type{Interval{T}}, ::Type{Interval{S}}) =
-    Interval{promote_type(T,S)}
+    Interval{promote_type(T, S)}
+
 promote_rule{T<:Real, S<:Real}(::Type{Interval{T}}, ::Type{S}) =
-    Interval{promote_type(T,S)}
+    Interval{promote_type(T, S)}
+
 promote_rule{T<:Real}(::Type{BigFloat}, ::Type{Interval{T}}) =
-    Interval{promote_type(T,BigFloat)}
+    Interval{promote_type(T, BigFloat)}

--- a/src/intervals/functions.jl
+++ b/src/intervals/functions.jl
@@ -2,25 +2,49 @@
 
 ## Powers
 # Integer power:
-function ^{T<:Real}(a::Interval{T}, n::Integer)
+
+# We do not have a correctly-rounded ^ function for Float64, so use the BigFloat
+# version which is correctly-rounded
+
+function big53(a::Interval{Float64})
+    x = with_interval_precision(53) do  # precision of Float64
+        Interval{BigFloat}(a)
+    end
+end
+
+function to_float(a::Interval{BigFloat})
+    Interval(Float64(a.lo), Float64(a.hi))
+end
+
+^(a::Interval{Float64}, x::Integer) = to_float(big53(a)^x)
+^(a::Interval{Float64}, x::Rational) = to_float(big53(a)^x)
+^(a::Interval{Float64}, x::Float64) = to_float(big53(a)^x)
+^(a::Interval{Float64}, x::BigFloat) = to_float(big53(a)^x)
+^(a::Interval{Float64}, x::Interval) = to_float((big53(a)^x))
+
+
+function ^(a::Interval{BigFloat}, n::Integer)
     isempty(a) && return a
     n == 0 && return one(a)
     n == 1 && return a
     n == 2 && return sqr(a)
     n < 0 && a == zero(a) && return emptyinterval(a)
 
+    T = BigFloat
+
     if isodd(n) # odd power
         isentire(a) && return a
         if n > 0
-            a.lo == zero(T) && return @controlled_round(T, zero(T), a.hi^n)
-            a.hi == zero(T) && return @controlled_round(T, a.lo^n, zero(T))
-            return @controlled_round(T, a.lo^n, a.hi^n)
+            a.lo == zero(T) && return @round(T, zero(T), a.hi^n)
+            a.hi == zero(T) && return @round(T, a.lo^n, zero(T))
+            return @round(T, a.lo^n, a.hi^n)
         else
             if a.lo ≥ zero(T)
-                a.lo == zero(T) && return @round(T, a.hi^n, convert(T,Inf))
+                a.lo == zero(T) && return @round(T, a.hi^n, convert(T, Inf))
                 return @round(T, a.hi^n, a.lo^n)
+
             elseif a.hi ≤ zero(T)
-                a.hi == zero(T) && return @round(T, convert(T,-Inf), a.lo^n)
+                a.hi == zero(T) && return @round(T, convert(T, -Inf), a.lo^n)
                 return @round(T, a.hi^n, a.lo^n)
             else
                 return entireinterval(a)
@@ -29,11 +53,11 @@ function ^{T<:Real}(a::Interval{T}, n::Integer)
     else # even power
         if n > 0
             if a.lo ≥ zero(T)
-                return @controlled_round(T, a.lo^n, a.hi^n)
+                return @round(T, a.lo^n, a.hi^n)
             elseif a.hi ≤ zero(T)
-                return @controlled_round(T, a.hi^n, a.lo^n)
+                return @round(T, a.hi^n, a.lo^n)
             else
-                return @controlled_round(T, mig(a)^n, mag(a)^n)
+                return @round(T, mig(a)^n, mag(a)^n)
             end
         else
             if a.lo ≥ zero(T)
@@ -46,21 +70,24 @@ function ^{T<:Real}(a::Interval{T}, n::Integer)
         end
     end
 end
+
 function sqr{T<:Real}(a::Interval{T})
     isempty(a) && return a
     if a.lo ≥ zero(T)
-        !isthin(a) && return @controlled_round(T, a.lo^2, a.hi^2)
-        return a*a
+        !isthin(a) && return @round(T, a.lo^2, a.hi^2)
+        return a^2  # a*a
     elseif a.hi ≤ zero(T)
-        !isthin(a) && return @controlled_round(T, a.hi^2, a.lo^2)
-        return a*a
-    else
-        return @controlled_round(T, mig(a)^2, mag(a)*mag(a))
+        !isthin(a) && return @round(T, a.hi^2, a.lo^2)
+        return a^2  # a*a
     end
+
+    return @round(T, mig(a)^2, mag(a)^2)  # mag(a)*mag(a))
+
 end
 
-# Floatingpoint power of a Float64/BigFloat interval:
-function ^{T<:Union{Float64,BigFloat}}(a::Interval{T}, x::AbstractFloat)
+# Floating-point power of a BigFloat interval:
+function ^(a::Interval{BigFloat}, x::AbstractFloat)
+    T = BigFloat
     domain = Interval(zero(T), Inf)
 
     if a == zero(a)
@@ -68,33 +95,26 @@ function ^{T<:Union{Float64,BigFloat}}(a::Interval{T}, x::AbstractFloat)
         x > zero(x) && return zero(a)
         return emptyinterval(a)
     end
-    isinteger(x) && return a^(round(Int,x))
+
+    isinteger(x) && return a^(round(Int, x))
     x == one(T)/2 && return sqrt(a)
 
     a = a ∩ domain
     (isempty(x) || isempty(a)) && return emptyinterval(a)
 
-    if T == BigFloat
-        xx  = @biginterval(x)
-        lo = @controlled_round(T, a.lo^xx.lo, a.lo^xx.lo)
-        lo1 = @controlled_round(T, a.lo^xx.hi, a.lo^xx.hi)
-        hi = @controlled_round(T, a.hi^xx.lo, a.hi^xx.lo)
-        hi1 = @controlled_round(T, a.hi^xx.hi, a.hi^xx.hi)
-        lo = hull(lo, lo1)
-        hi = hull(hi, hi1)
-    else
-        lo, hi = with_bigfloat_precision(53) do
-            aa = Interval(big(a.lo), big(a.hi)) # before: @biginterval(a)
-            xx = @biginterval(x)
-            lo = @controlled_round(BigFloat, a.lo^xx.lo, a.lo^xx.lo)
-            lo1 = @controlled_round(BigFloat, a.lo^xx.hi, a.lo^xx.hi)
-            hi = @controlled_round(BigFloat, a.hi^xx.lo, a.hi^xx.lo)
-            hi1 = @controlled_round(BigFloat, a.hi^xx.hi, a.hi^xx.hi)
-            float(hull(lo, lo1)), float(hull(hi, hi1))
-        end
-    end
+    xx = @interval(x)
+
+    lo = @round(T, a.lo^xx.lo, a.lo^xx.lo)
+    lo1 = @round(T, a.lo^xx.hi, a.lo^xx.hi)
+    hi = @round(T, a.hi^xx.lo, a.hi^xx.lo)
+    hi1 = @round(T, a.hi^xx.hi, a.hi^xx.hi)
+
+    lo = hull(lo, lo1)
+    hi = hull(hi, hi1)
+
     return hull(lo, hi)
 end
+
 function ^{T<:Integer,}(a::Interval{Rational{T}}, x::AbstractFloat)
     a = Interval(a.lo.num/a.lo.den, a.hi.num/a.hi.den)
     a = a^x
@@ -102,7 +122,8 @@ function ^{T<:Integer,}(a::Interval{Rational{T}}, x::AbstractFloat)
 end
 
 # Rational power
-function ^{T<:Real, S<:Integer}(a::Interval{T}, r::Rational{S})
+function ^{S<:Integer}(a::Interval{BigFloat}, r::Rational{S})
+    T = BigFloat
     domain = Interval(zero(a.lo), Inf)
 
     if a == zero(a)
@@ -110,7 +131,8 @@ function ^{T<:Real, S<:Integer}(a::Interval{T}, r::Rational{S})
         r > zero(r) && return zero(a)
         return emptyinterval(a)
     end
-    isinteger(r) && return make_interval(T, a^(round(S,r)))
+
+    isinteger(r) && return make_interval(T, a^round(S,r))
     r == one(S)//2 && return make_interval(T, sqrt(a))
 
     a = a ∩ domain
@@ -118,11 +140,13 @@ function ^{T<:Real, S<:Integer}(a::Interval{T}, r::Rational{S})
 
     r = r.num / r.den
     a = a^r
+
     make_interval(T, a)
 end
 
 # Interval power of an interval:
-function ^{T<:Real}(a::Interval{T}, x::Interval)
+function ^(a::Interval{BigFloat}, x::Interval)
+    T = BigFloat
     domain = Interval(zero(T), Inf)
 
     a = a ∩ domain
@@ -131,11 +155,11 @@ function ^{T<:Real}(a::Interval{T}, x::Interval)
 
     lo1 = a^x.lo
     lo2 = a^x.hi
-    lo1 = hull( lo1, lo2 )
+    lo1 = hull(lo1, lo2)
 
     hi1 = a^x.lo
     hi2 = a^x.hi
-    hi1 = hull( hi1, hi2 )
+    hi1 = hull(hi1, hi2)
 
     hull(lo1, hi1)
 end
@@ -150,7 +174,7 @@ function sqrt{T}(a::Interval{T})
 
     isempty(a) && return a
 
-    @controlled_round(T, sqrt(a.lo), sqrt(a.hi))
+    @round(T, sqrt(a.lo), sqrt(a.hi))  # `sqrt` is correctly-rounded
 end
 
 

--- a/src/intervals/functions.jl
+++ b/src/intervals/functions.jl
@@ -13,7 +13,7 @@ function big53(a::Interval{Float64})
 end
 
 function to_float(a::Interval{BigFloat})
-    Interval(Float64(a.lo), Float64(a.hi))
+    Interval(Float64(a.lo), Float64(a.hi))  # convert without further rounding
 end
 
 ^(a::Interval{Float64}, x::Integer) = to_float(big53(a)^x)
@@ -74,11 +74,12 @@ end
 function sqr{T<:Real}(a::Interval{T})
     isempty(a) && return a
     if a.lo ≥ zero(T)
-        !isthin(a) && return @round(T, a.lo^2, a.hi^2)
-        return a^2  # a*a
+        isthin(a) && return Interval(a.lo^2)  # a*a
+        return @round(T, a.lo^2, a.hi^2)
+
     elseif a.hi ≤ zero(T)
-        !isthin(a) && return @round(T, a.hi^2, a.lo^2)
-        return a^2  # a*a
+        isthin(a) && return Interval(a.lo^2)  # a*a
+        return @round(T, a.hi^2, a.lo^2)
     end
 
     return @round(T, mig(a)^2, mag(a)^2)  # mag(a)*mag(a))

--- a/src/intervals/hyperbolic_functions.jl
+++ b/src/intervals/hyperbolic_functions.jl
@@ -1,91 +1,55 @@
 # This file is part of the ValidatedNumerics.jl package; MIT licensed
 
 
-function sinh(a::Interval{Float64})
+function sinh{T}(a::Interval{T})
     isempty(a) && return a
     return Interval(sinh(a.lo, RoundDown), sinh(a.hi, RoundUp))
 end
 
-function sinh(a::Interval{BigFloat})
-    isempty(a) && return a
-    return @controlled_round(BigFloat, sinh(a.lo), sinh(a.hi))
-end
-
-
-function cosh(a::Interval{Float64})
+function cosh{T}(a::Interval{T})
     isempty(a) && return a
     return Interval(cosh(mig(a), RoundDown), cosh(mag(a), RoundUp))
 end
 
-function cosh(a::Interval{BigFloat})
-    isempty(a) && return a
-    return @controlled_round(BigFloat, cosh(mig(a)), cosh(mag(a)))
-end
-
-
 function tanh(a::Interval{Float64})
     isempty(a) && return a
-    res = with_bigfloat_precision(53) do
-        aa = Interval(big(a.lo), big(a.hi))
-        float( tanh(aa) )
-    end
-    return res
+
+    to_float(tanh(big53(a)))
 end
 
 function tanh(a::Interval{BigFloat})
     isempty(a) && return a
-    return @controlled_round(BigFloat, tanh(a.lo), tanh(a.hi))
+    return @round(BigFloat, tanh(a.lo), tanh(a.hi))
 end
 
-
-function asinh(a::Interval{Float64})
-    isempty(a) && return a
-    res = with_bigfloat_precision(53) do
-        aa = Interval(big(a.lo), big(a.hi))
-        float( asinh(aa) )
-    end
-    return res
-end
 
 function asinh(a::Interval{BigFloat})
     isempty(a) && return a
-    @controlled_round(BigFloat, asinh(a.lo), asinh(a.hi))
+    @round(BigFloat, asinh(a.lo), asinh(a.hi))
 end
 
-
-function acosh(a::Interval{Float64})
-    domain = Interval(one(eltype(a)), Inf)
-    a = a ∩ domain
-    isempty(a) && return a
-    res = with_bigfloat_precision(53) do
-        aa = Interval(big(a.lo), big(a.hi))
-        float( acosh(aa) )
-    end
-    return res
-end
 
 function acosh(a::Interval{BigFloat})
     domain = Interval(one(eltype(a)), Inf)
     a = a ∩ domain
     isempty(a) && return a
-    @controlled_round(BigFloat, acosh(a.lo), acosh(a.hi))
+    @round(BigFloat, acosh(a.lo), acosh(a.hi))
 end
 
-
-function atanh(a::Interval{Float64})
-    domain = Interval(-one(eltype(a)), one(eltype(a)))
-    a = a ∩ domain
-    (isempty(a) || abs(a) == one(a)) && return emptyinterval(a)
-    res = with_bigfloat_precision(53) do
-        aa = Interval(big(a.lo), big(a.hi))
-        float( atanh(aa) )
-    end
-    return res
-end
 
 function atanh(a::Interval{BigFloat})
     domain = Interval(-one(eltype(a)), one(eltype(a)))
     a = a ∩ domain
     isempty(a) && return a
     @controlled_round(BigFloat, atanh(a.lo), atanh(a.hi))
+end
+
+# Float64 versions of functions missing from CRlibm:
+for f in (:tanh, :asinh, :acosh, :atanh)
+
+    @eval function ($f)(a::Interval{Float64})
+        isempty(a) && return a
+
+        to_float(($f)(big53(a)))
+    end
 end

--- a/src/intervals/intervals.jl
+++ b/src/intervals/intervals.jl
@@ -16,7 +16,7 @@ immutable Interval{T<:Real} <: Real
         if a > b
             throw(ArgumentError("Must have a ≤ b to construct Interval(a, b)."))
         end
-        
+
         new(a, b)
     end
 end

--- a/src/intervals/intervals.jl
+++ b/src/intervals/intervals.jl
@@ -11,11 +11,12 @@ immutable Interval{T<:Real} <: Real
 
     function Interval(a::Real, b::Real)
         # The following exception is needed to define emptyintervals as [∞,-∞]
-        (isinf(a) && isinf(b)) && return new(a,b)
+        (isinf(a) && isinf(b)) && return new(a, b)
 
         if a > b
-            a, b = b, a
+            throw(ArgumentError("Must have a ≤ b to construct Interval(a, b)."))
         end
+        
         new(a, b)
     end
 end

--- a/src/intervals/macro_definitions.jl
+++ b/src/intervals/macro_definitions.jl
@@ -1,6 +1,6 @@
 # This file is part of the ValidatedNumerics.jl package; MIT licensed
 
-@doc doc"""The `@interval` macro is the main way to create an interval of `BigFloat`s.
+ doc"""The `@interval` macro is the main way to create an interval of `BigFloat`s.
 It converts each expression into a thin interval that is guaranteed to contain the true value passed
 by the user in the one or two expressions passed to it.
 It takes the hull of the resulting intervals (if necessary, i.e. when given two expressions)
@@ -22,7 +22,7 @@ macro interval(expr1, expr2...)
     make_interval(:(interval_parameters.precision_type), expr1, expr2)
 end
 
-@doc doc"""The `floatinterval` macro constructs an interval with `Float64` entries,
+ doc"""The `floatinterval` macro constructs an interval with `Float64` entries,
 instead of `BigFloat`.""" ->
 
 macro floatinterval(expr1, expr2...)

--- a/src/intervals/macro_definitions.jl
+++ b/src/intervals/macro_definitions.jl
@@ -16,14 +16,14 @@ Examples:
 
     @interval(1/3^2)
 ```
-""" ->
+"""
 
 macro interval(expr1, expr2...)
     make_interval(:(parameters.precision_type), expr1, expr2)
 end
 
  doc"""The `floatinterval` macro constructs an interval with `Float64` entries,
-instead of `BigFloat`.""" ->
+instead of `BigFloat`."""
 
 macro floatinterval(expr1, expr2...)
     make_interval(Float64, expr1, expr2)

--- a/src/intervals/macro_definitions.jl
+++ b/src/intervals/macro_definitions.jl
@@ -1,9 +1,8 @@
 # This file is part of the ValidatedNumerics.jl package; MIT licensed
 
- doc"""The `@interval` macro is the main way to create an interval of `BigFloat`s.
-It converts each expression into a thin interval that is guaranteed to contain the true value passed
-by the user in the one or two expressions passed to it.
-It takes the hull of the resulting intervals (if necessary, i.e. when given two expressions)
+doc"""The `@interval` macro is the main method to create an interval.
+It converts each expression into a narrow interval that is guaranteed to contain the true value passed by the user in the one or two expressions passed to it.
+When passed two expressions, it takes the hull of the resulting intervals
 to give a guaranteed containing interval.
 
 Examples:
@@ -17,18 +16,16 @@ Examples:
     @interval(1/3^2)
 ```
 """
-
 macro interval(expr1, expr2...)
     make_interval(:(parameters.precision_type), expr1, expr2)
 end
 
- doc"""The `floatinterval` macro constructs an interval with `Float64` entries,
-instead of `BigFloat`."""
-
+doc"The `@floatinterval` macro constructs an interval with `Float64` entries."
 macro floatinterval(expr1, expr2...)
     make_interval(Float64, expr1, expr2)
 end
 
+doc"The `@biginterval` macro constructs an interval with `BigFloat` entries."
 macro biginterval(expr1, expr2...)
     make_interval(BigFloat, expr1, expr2)
 end

--- a/src/intervals/macro_definitions.jl
+++ b/src/intervals/macro_definitions.jl
@@ -19,7 +19,7 @@ Examples:
 """ ->
 
 macro interval(expr1, expr2...)
-    make_interval(:(interval_parameters.precision_type), expr1, expr2)
+    make_interval(:(parameters.precision_type), expr1, expr2)
 end
 
  doc"""The `floatinterval` macro constructs an interval with `Float64` entries,

--- a/src/intervals/parameters.jl
+++ b/src/intervals/parameters.jl
@@ -11,4 +11,4 @@ type IntervalParameters
 end
 
 
-const interval_parameters = IntervalParameters()
+const parameters = IntervalParameters()

--- a/src/intervals/precision.jl
+++ b/src/intervals/precision.jl
@@ -2,16 +2,16 @@
 
 ## Precision:
 
-set_interval_precision(::Type{Float64}, prec=-1) =  interval_parameters.precision_type = Float64
+set_interval_precision(::Type{Float64}, prec=-1) =  parameters.precision_type = Float64
 # don't change precision, which is just for BigFloat
 
 
 function set_interval_precision(::Type{BigFloat}, prec::Int=256)
     set_bigfloat_precision(prec)
 
-    interval_parameters.precision_type = BigFloat
-    interval_parameters.precision = prec
-    interval_parameters.pi = make_interval(BigFloat, pi)
+    parameters.precision_type = BigFloat
+    parameters.precision = prec
+    parameters.pi = make_interval(BigFloat, pi)
 
     prec
 end
@@ -30,17 +30,17 @@ set_interval_precision(prec) = set_interval_precision(BigFloat, prec)
 set_interval_precision(t::Tuple) = set_interval_precision(t...)
 
 get_interval_precision() =
-    interval_parameters.precision_type == Float64 ? (Float64, -1) : (BigFloat, interval_parameters.precision)
+    parameters.precision_type == Float64 ? (Float64, -1) : (BigFloat, parameters.precision)
 
 
 
 
 const float_interval_pi = make_interval(Float64, pi)  # does not change
 
-pi_interval(::Type{BigFloat}) = interval_parameters.pi
+pi_interval(::Type{BigFloat}) = parameters.pi
 pi_interval(::Type{Float64}) = float_interval_pi
 
 ## Setup default parameters
 
-set_interval_precision(256)  # to define interval_parameters.pi
+set_interval_precision(256)  # to define parameters.pi
 set_interval_precision(Float64)

--- a/src/intervals/precision.jl
+++ b/src/intervals/precision.jl
@@ -2,23 +2,22 @@
 
 ## Precision:
 
-set_interval_precision(::Type{Float64}, prec=-1) =  parameters.precision_type = Float64
-# don't change precision, which is just for BigFloat
+set_interval_precision(::Type{Float64}, prec=-1) = parameters.precision_type = Float64
 
 
-function set_interval_precision(::Type{BigFloat}, prec::Int=256)
-    set_bigfloat_precision(prec)
+function set_interval_precision(::Type{BigFloat}, precision::Integer=256)
+    set_bigfloat_precision(precision)
 
     parameters.precision_type = BigFloat
-    parameters.precision = prec
+    parameters.precision = precision
     parameters.pi = make_interval(BigFloat, pi)
 
-    prec
+    precision
 end
 
-function with_interval_precision(f::Function, prec::Int=256)
+function with_interval_precision(f::Function, precision::Integer=256)
     old_interval_precision = get_interval_precision()
-    set_interval_precision(prec)
+    set_interval_precision(precision)
     try
         return f()
     finally
@@ -26,21 +25,14 @@ function with_interval_precision(f::Function, prec::Int=256)
     end
 end
 
-set_interval_precision(prec) = set_interval_precision(BigFloat, prec)
+set_interval_precision(precision) = set_interval_precision(BigFloat, precision)
 set_interval_precision(t::Tuple) = set_interval_precision(t...)
 
 get_interval_precision() =
     parameters.precision_type == Float64 ? (Float64, -1) : (BigFloat, parameters.precision)
 
 
-
-
 const float_interval_pi = make_interval(Float64, pi)  # does not change
 
 pi_interval(::Type{BigFloat}) = parameters.pi
-pi_interval(::Type{Float64}) = float_interval_pi
-
-## Setup default parameters
-
-set_interval_precision(256)  # to define parameters.pi
-set_interval_precision(Float64)
+pi_interval(::Type{Float64})  = float_interval_pi

--- a/src/intervals/rounding.jl
+++ b/src/intervals/rounding.jl
@@ -258,12 +258,12 @@ This gives the narrowest possible interval.
 `prevfloat` and `nextfloat` to achieve directed rounding. This creates an interval of width 2`eps`.
 """ ->
 
-get_interval_rounding() = interval_parameters.rounding
+get_interval_rounding() = parameters.rounding
 
 function set_interval_rounding(mode)
     if mode ∉ [:wide, :narrow]
         throw(ArgumentError("Only possible interval rounding modes are `:wide` and `:narrow`"))
     end
 
-    interval_parameters.rounding = mode  # a symbol
+    parameters.rounding = mode  # a symbol
 end

--- a/src/intervals/rounding.jl
+++ b/src/intervals/rounding.jl
@@ -6,20 +6,15 @@
 Base.set_rounding(whatever, rounding_mode) = ()
 Base.get_rounding(whatever) = ()
 
-if VERSION > v"0.4-"
-    Base.Rounding.get_rounding_raw(whatever) = ()
-    Base.Rounding.set_rounding_raw(whatever, rounding_mode) = ()
-end
+Base.Rounding.get_rounding_raw(whatever) = Base.Rounding.set_rounding_raw(whatever, rounding_mode) = ()
 
 
 macro show_rounding(T, expr)
    quote
-       ee = @with_rounding($T, $expr, RoundNearest)
-       @show "Nearest", ee
-       ee = @with_rounding($T, $expr, RoundDown)
-       @show "Down   ", ee
-       ee = @with_rounding($T, $expr, RoundUp)
-       @show "Up     ", ee
+       for mode in (:RoundNearest, :RoundDown, :RoundUp)
+           ex = @with_rounding($T, $expr, $mode)
+           @show mode, ex
+       end
    end
 end
 
@@ -35,8 +30,7 @@ end
 
  doc"""The `@round` macro creates a rounded interval according to the current
 interval rounding mode. It is the main function used to create intervals in the
-library (e.g. when adding two intervals, etc.). It uses the interval rounding mode
-(see get_interval_rounding())""" ->
+library (e.g. when adding two intervals, etc.). It uses the interval rounding mode (see get_interval_rounding())"""
 macro round(T, expr1, expr2)
     #@show "round", expr1, expr2
     quote
@@ -88,15 +82,15 @@ macro controlled_round(T, expr1, expr2)
     end
 end
 
- doc"""`@thin_round` possibly saves one operation compared to `@round`.""" ->
+doc"""`@thin_round` possibly saves one operation compared to `@round`."""
 macro thin_round(T, expr)
     quote
         @round($T, $expr, $expr)
     end
 end
 
- doc"""`split_interval_string` deals with strings of the form
-\"[3.5, 7.2]\"""" ->
+doc"""`split_interval_string` deals with strings of the form
+\"[3.5, 7.2]\""""
 
 function split_interval_string(T, x::AbstractString)
     if !(contains(x, "["))
@@ -114,8 +108,7 @@ end
 
 
  doc"""`make_interval` is used by `@interval` to create intervals from
-individual elements of different types""" ->
-
+individual elements of different types"""
 # make_interval for BigFloat intervals
 make_interval(::Type{BigFloat}, x::AbstractString) =
     split_interval_string(BigFloat, x)
@@ -189,7 +182,7 @@ end
 
  doc"""`transform` transforms a string by applying the function `f` and type
 `T` to each argument, i.e. `:(x+y)` is transformed to `:(f(T, x) + f(T, y))`
-""" ->
+"""
 transform(x, f, T) = :($f($(esc(T)), $(esc(x))))   # use if x is not an expression
 
 function transform(expr::Expr, f::Symbol, T)
@@ -224,9 +217,9 @@ end
 
 
 # Called by interval and floatinterval macros
- doc"""`make_interval` does the hard work of taking expressions
+doc"""`make_interval` does the hard work of taking expressions
 and making each literal (0.1, 1, etc.) into a corresponding interval construction,
-by calling `transform`.""" ->
+by calling `transform`."""
 
 function make_interval(T, expr1, expr2)
     expr1 = transform(expr1, :make_interval, T)
@@ -256,7 +249,7 @@ This gives the narrowest possible interval.
 
 - :wide -- Leaves the floating-point rounding mode in `RoundNearest` and uses
 `prevfloat` and `nextfloat` to achieve directed rounding. This creates an interval of width 2`eps`.
-""" ->
+"""
 
 get_interval_rounding() = parameters.rounding
 

--- a/src/intervals/rounding.jl
+++ b/src/intervals/rounding.jl
@@ -33,7 +33,7 @@ macro with_rounding(T, expr, rounding_mode)
 end
 
 
-@doc doc"""The `@round` macro creates a rounded interval according to the current
+ doc"""The `@round` macro creates a rounded interval according to the current
 interval rounding mode. It is the main function used to create intervals in the
 library (e.g. when adding two intervals, etc.). It uses the interval rounding mode
 (see get_interval_rounding())""" ->
@@ -88,14 +88,14 @@ macro controlled_round(T, expr1, expr2)
     end
 end
 
-@doc doc"""`@thin_round` possibly saves one operation compared to `@round`.""" ->
+ doc"""`@thin_round` possibly saves one operation compared to `@round`.""" ->
 macro thin_round(T, expr)
     quote
         @round($T, $expr, $expr)
     end
 end
 
-@doc doc"""`split_interval_string` deals with strings of the form
+ doc"""`split_interval_string` deals with strings of the form
 \"[3.5, 7.2]\"""" ->
 
 function split_interval_string(T, x::AbstractString)
@@ -113,7 +113,7 @@ function split_interval_string(T, x::AbstractString)
 end
 
 
-@doc doc"""`make_interval` is used by `@interval` to create intervals from
+ doc"""`make_interval` is used by `@interval` to create intervals from
 individual elements of different types""" ->
 
 # make_interval for BigFloat intervals
@@ -187,7 +187,7 @@ function make_interval{T<:Integer}(::Type{Rational{T}}, x::Interval)
 end
 
 
-@doc doc"""`transform` transforms a string by applying the function `f` and type
+ doc"""`transform` transforms a string by applying the function `f` and type
 `T` to each argument, i.e. `:(x+y)` is transformed to `:(f(T, x) + f(T, y))`
 """ ->
 transform(x, f, T) = :($f($(esc(T)), $(esc(x))))   # use if x is not an expression
@@ -224,7 +224,7 @@ end
 
 
 # Called by interval and floatinterval macros
-@doc doc"""`make_interval` does the hard work of taking expressions
+ doc"""`make_interval` does the hard work of taking expressions
 and making each literal (0.1, 1, etc.) into a corresponding interval construction,
 by calling `transform`.""" ->
 
@@ -248,7 +248,7 @@ float(x::Interval) =
 ## Change type of interval rounding:
 
 
-@doc doc"""`get_interval_rounding()` returns the current interval rounding mode.
+ doc"""`get_interval_rounding()` returns the current interval rounding mode.
 There are two possible rounding modes:
 
 - :narrow  -- changes the floating-point rounding mode to `RoundUp` and `RoundDown`.

--- a/src/intervals/special_intervals.jl
+++ b/src/intervals/special_intervals.jl
@@ -3,7 +3,7 @@
 ## Definitions of special intervals
 
 ## Empty interval:
-@doc doc"""`emptyinterval`s are represented as the interval [∞, -∞]; note
+doc"""`emptyinterval`s are represented as the interval [∞, -∞]; note
 that this interval is an exception to the fact that the lower bound is
 larger than the upper one.""" ->
 
@@ -16,7 +16,7 @@ isempty(x::Interval) = x.lo == Inf && x.hi == -Inf
 
 
 ## Entire interval:
-@doc doc"""`entireinterval`s represent the whole Real line: [-∞, ∞].""" ->
+doc"""`entireinterval`s represent the whole Real line: [-∞, ∞].""" ->
 entireinterval{T<:Real}(::Type{T}) = Interval{T}(-Inf, Inf)
 entireinterval{T<:Real}(x::Interval{T}) = entireinterval(T)
 entireinterval() = entireinterval(get_interval_precision()[1])
@@ -26,7 +26,7 @@ isunbounded(x::Interval) = x.lo == -Inf || x.hi == Inf
 
 
 # NaI: not-an-interval
-@doc doc"""`NaI` not-an-interval: [NaN, NaN].""" ->
+doc"""`NaI` not-an-interval: [NaN, NaN].""" ->
 nai{T<:Real}(::Type{T}) = Interval{T}(NaN,NaN)
 nai{T<:Real}(x::Interval{T}) = nai(T)
 nai() = nai(get_interval_precision()[1])
@@ -34,20 +34,17 @@ nai() = nai(get_interval_precision()[1])
 isnai(x::Interval) = isnan(x.lo) || isnan(x.hi)
 
 
-## isthin corresponds to isSingleton; note that an interval corresponding
-# to any float which is not exactly representable in a binary expansion
-# does not yield a thin interval
+doc"""`isthin(x)` corresponds to `isSingleton`, i.e. it checks if `x` is the set consisting of a single exactly representable float. Thus any float which is not exactly representable does *not* yield a thin interval."""
 function isthin(x::Interval)
     # (m = mid(x); m == x.lo || m == x.hi)
     x.lo == x.hi
 end
 
-
-# A common is a nonempty bounded real interval
+doc"`iscommon(x)` checks if `x` is a **common interval**, i.e. a non-empty, bounded, real interval."
 function iscommon(a::Interval)
     (isentire(a) || isempty(a) || isnai(a) || isunbounded(a)) && return false
     true
 end
 
-## Widen:
+doc"`widen(x)` widens the lowest and highest bounds of `x` to the previous and next representable floating-point numbers, respectively."
 widen{T<:AbstractFloat}(x::Interval{T}) = Interval(prevfloat(x.lo), nextfloat(x.hi))

--- a/src/intervals/special_intervals.jl
+++ b/src/intervals/special_intervals.jl
@@ -5,8 +5,7 @@
 ## Empty interval:
 doc"""`emptyinterval`s are represented as the interval [∞, -∞]; note
 that this interval is an exception to the fact that the lower bound is
-larger than the upper one.""" ->
-
+larger than the upper one.""" 
 emptyinterval{T<:Real}(::Type{T}) = Interval{T}(Inf, -Inf)
 emptyinterval{T<:Real}(x::Interval{T}) = emptyinterval(T)
 emptyinterval() = emptyinterval(get_interval_precision()[1])
@@ -16,7 +15,7 @@ isempty(x::Interval) = x.lo == Inf && x.hi == -Inf
 
 
 ## Entire interval:
-doc"""`entireinterval`s represent the whole Real line: [-∞, ∞].""" ->
+doc"""`entireinterval`s represent the whole Real line: [-∞, ∞]."""
 entireinterval{T<:Real}(::Type{T}) = Interval{T}(-Inf, Inf)
 entireinterval{T<:Real}(x::Interval{T}) = entireinterval(T)
 entireinterval() = entireinterval(get_interval_precision()[1])
@@ -26,7 +25,7 @@ isunbounded(x::Interval) = x.lo == -Inf || x.hi == Inf
 
 
 # NaI: not-an-interval
-doc"""`NaI` not-an-interval: [NaN, NaN].""" ->
+doc"""`NaI` not-an-interval: [NaN, NaN]."""
 nai{T<:Real}(::Type{T}) = Interval{T}(NaN,NaN)
 nai{T<:Real}(x::Interval{T}) = nai(T)
 nai() = nai(get_interval_precision()[1])

--- a/src/intervals/trigonometric_functions.jl
+++ b/src/intervals/trigonometric_functions.jl
@@ -17,7 +17,7 @@ is returned. The minimum or maximum must then be chosen appropriately.
 
 This is a rather indirect way to determine if π/2 and 3π/2 are contained
 in the interval; cf. the formula for sine of an interval in
-Tucker, *Validated Numerics*.""" ->
+Tucker, *Validated Numerics*."""
 
 function find_quadrants(x::AbstractFloat)
     temp = x / half_pi(x)

--- a/src/intervals/trigonometric_functions.jl
+++ b/src/intervals/trigonometric_functions.jl
@@ -10,7 +10,7 @@ half_range_atan2{T}(::Type{T}) = (temp = half_pi(T); Interval(-(temp.hi), temp.h
 pos_range_atan2{T<:Real}(::Type{T}) = Interval(zero(T), pi_interval(T).hi)
 
 
-@doc doc"""Finds the quadrant(s) corresponding to a given floating-point
+ doc"""Finds the quadrant(s) corresponding to a given floating-point
 number. The quadrants are labelled as 0 for x ∈ [0, π/2], etc.
 For numbers very near a boundary of the quadrant, a tuple of two quadrants
 is returned. The minimum or maximum must then be chosen appropriately.

--- a/src/intervals/trigonometric_functions.jl
+++ b/src/intervals/trigonometric_functions.jl
@@ -120,7 +120,7 @@ function tan{T}(a::Interval{T})
     return Interval(tan(a.lo, RoundDown), tan(a.hi, RoundUp))
 end
 
-function asin{T}(a::Interval{t})
+function asin{T}(a::Interval{T})
 
     domain = Interval(-one(T), one(T))
     a = a ∩ domain
@@ -130,7 +130,7 @@ function asin{T}(a::Interval{t})
     Interval(asin(a.lo, RoundDown), asin(a.hi, RoundUp))
 end
 
-function acos(a::Interval{T})
+function acos{T}(a::Interval{T})
 
     domain = Interval(-one(T), one(T))
     a = a ∩ domain
@@ -207,9 +207,9 @@ function atan2(y::Interval{BigFloat}, x::Interval{BigFloat})
         elseif x.hi == zero(T)
             y == zero(y) && return pi_interval(T)
             y.lo ≥ zero(T) &&
-                return @round(T, big(pi)/2, atan2(y.lo, x.lo))
+                return @round(T, half_pi(T).lo, atan2(y.lo, x.lo))
             y.hi < zero(T) &&
-                return @round(T, atan2(y.hi, x.lo), big(-pi)/2)
+                return @round(T, atan2(y.hi, x.lo), -(half_pi(T).lo))
             return range_atan2(T)
         else
             y.lo ≥ zero(T) &&

--- a/src/intervals/trigonometric_functions.jl
+++ b/src/intervals/trigonometric_functions.jl
@@ -10,7 +10,7 @@ half_range_atan2{T}(::Type{T}) = (temp = half_pi(T); Interval(-(temp.hi), temp.h
 pos_range_atan2{T<:Real}(::Type{T}) = Interval(zero(T), pi_interval(T).hi)
 
 
- doc"""Finds the quadrant(s) corresponding to a given floating-point
+doc"""Finds the quadrant(s) corresponding to a given floating-point
 number. The quadrants are labelled as 0 for x ∈ [0, π/2], etc.
 For numbers very near a boundary of the quadrant, a tuple of two quadrants
 is returned. The minimum or maximum must then be chosen appropriately.
@@ -24,9 +24,8 @@ function find_quadrants(x::AbstractFloat)
     (floor(Int, temp.lo), floor(Int, temp.hi))
 end
 
-function sin(a::Interval{Float64})
+function sin{T}(a::Interval{T})
     isempty(a) && return a
-    T = Float64
 
     whole_range = Interval(-one(T), one(T))
 
@@ -62,48 +61,9 @@ function sin(a::Interval{Float64})
     end
 end
 
-function sin(a::Interval{BigFloat})
+
+function cos{T}(a::Interval{T})
     isempty(a) && return a
-    T = BigFloat
-
-    whole_range = Interval(-one(T), one(T))
-
-    diam(a) > two_pi(T).lo && return whole_range
-
-    lo_quadrant = minimum(find_quadrants(a.lo))
-    hi_quadrant = maximum(find_quadrants(a.hi))
-
-    lo_quadrant = mod(lo_quadrant, 4)
-    hi_quadrant = mod(hi_quadrant, 4)
-
-    # Different cases depending on the two quadrants:
-    if lo_quadrant == hi_quadrant
-        a.hi - a.lo > pi_interval(T).lo && return whole_range  # in same quadrant but separated by almost 2pi
-        lo = @controlled_round(T, sin(a.lo), sin(a.lo))
-        hi = @controlled_round(T, sin(a.hi), sin(a.hi))
-        return hull(lo, hi)
-
-    elseif lo_quadrant==3 && hi_quadrant==0
-        return @controlled_round(T, sin(a.lo), sin(a.hi))
-
-    elseif lo_quadrant==1 && hi_quadrant==2
-        return @controlled_round(T, sin(a.hi), sin(a.lo))
-
-    elseif ( lo_quadrant == 0 || lo_quadrant==3 ) && ( hi_quadrant==1 || hi_quadrant==2 )
-        return @controlled_round(T, min(sin(a.lo), sin(a.hi)), one(T))
-
-    elseif ( lo_quadrant == 1 || lo_quadrant==2 ) && ( hi_quadrant==3 || hi_quadrant==0 )
-        return @controlled_round(T, -one(T), max(sin(a.lo), sin(a.hi)))
-
-    else#if ( lo_quadrant == 0 && hi_quadrant==3 ) || ( lo_quadrant == 2 && hi_quadrant==1 )
-        return whole_range
-    end
-end
-
-
-function cos(a::Interval{Float64})
-    isempty(a) && return a
-    T = Float64
 
     whole_range = Interval(-one(T), one(T))
 
@@ -139,48 +99,9 @@ function cos(a::Interval{Float64})
     end
 end
 
-function cos(a::Interval{BigFloat})
+
+function tan{T}(a::Interval{T})
     isempty(a) && return a
-    T = BigFloat
-
-    whole_range = Interval(-one(T), one(T))
-
-    diam(a) > two_pi(T).lo && return whole_range
-
-    lo_quadrant = minimum(find_quadrants(a.lo))
-    hi_quadrant = maximum(find_quadrants(a.hi))
-
-    lo_quadrant = mod(lo_quadrant, 4)
-    hi_quadrant = mod(hi_quadrant, 4)
-
-    # Different cases depending on the two quadrants:
-    if lo_quadrant == hi_quadrant # Interval limits in the same quadrant
-        a.hi - a.lo > pi_interval(T).lo && return whole_range
-        lo = @controlled_round(T, cos(a.lo), cos(a.lo))
-        hi = @controlled_round(T, cos(a.hi), cos(a.hi))
-        return hull(lo, hi)
-
-    elseif lo_quadrant == 2 && hi_quadrant==3
-        return @controlled_round(T, cos(a.lo), cos(a.hi))
-
-    elseif lo_quadrant == 0 && hi_quadrant==1
-        return @controlled_round(T, cos(a.hi), cos(a.lo))
-
-    elseif ( lo_quadrant == 2 || lo_quadrant==3 ) && ( hi_quadrant==0 || hi_quadrant==1 )
-        return @controlled_round(T, min(cos(a.lo), cos(a.hi)), one(T))
-
-    elseif ( lo_quadrant == 0 || lo_quadrant==1 ) && ( hi_quadrant==2 || hi_quadrant==3 )
-        return @controlled_round(T, -one(T), max(cos(a.lo), cos(a.hi)))
-
-    else#if ( lo_quadrant == 3 && hi_quadrant==2 ) || ( lo_quadrant == 1 && hi_quadrant==0 )
-        return whole_range
-    end
-end
-
-
-function tan(a::Interval{Float64})
-    isempty(a) && return a
-    T = Float64
 
     diam(a) > pi_interval(T).lo && return entireinterval(a)
 
@@ -199,33 +120,9 @@ function tan(a::Interval{Float64})
     return Interval(tan(a.lo, RoundDown), tan(a.hi, RoundUp))
 end
 
-function tan(a::Interval{BigFloat})
-    isempty(a) && return a
-    T = BigFloat
-
-    diam(a) > pi_interval(T).lo && return entireinterval(a)
-
-    lo_quadrant = minimum(find_quadrants(a.lo))
-    hi_quadrant = maximum(find_quadrants(a.hi))
-
-    lo_quadrant_mod = mod(lo_quadrant, 2)
-    hi_quadrant_mod = mod(hi_quadrant, 2)
-
-    if lo_quadrant_mod == 0 && hi_quadrant_mod == 1
-        (half_pi(T) ⊆ a || -half_pi(T) ⊆ a) && return entireinterval(a)
-    elseif lo_quadrant_mod == hi_quadrant_mod && hi_quadrant > lo_quadrant
-        hi_quadrant == lo_quadrant+2 && return entireinterval(a)
-    end
-
-    return @controlled_round(T, tan(a.lo), tan(a.hi))
-end
-
-
-function asin(a::Interval{Float64})
-    T = Float64
+function asin{T}(a::Interval{t})
 
     domain = Interval(-one(T), one(T))
-
     a = a ∩ domain
 
     isempty(a) && return a
@@ -233,24 +130,9 @@ function asin(a::Interval{Float64})
     Interval(asin(a.lo, RoundDown), asin(a.hi, RoundUp))
 end
 
-function asin(a::Interval{BigFloat})
-    T = BigFloat
+function acos(a::Interval{T})
 
     domain = Interval(-one(T), one(T))
-
-    a = a ∩ domain
-
-    isempty(a) && return a
-
-    @controlled_round(T, asin(a.lo), asin(a.hi))
-end
-
-
-function acos(a::Interval{Float64})
-    T = Float64
-
-    domain = Interval(-one(T), one(T))
-
     a = a ∩ domain
 
     isempty(a) && return a
@@ -258,40 +140,20 @@ function acos(a::Interval{Float64})
     Interval(acos(a.hi, RoundDown), acos(a.lo, RoundUp))
 end
 
-function acos(a::Interval{BigFloat})
-    T = BigFloat
 
-    domain = Interval(-one(T), one(T))
-
-    a = a ∩ domain
-
-    isempty(a) && return a
-
-    @controlled_round(T, acos(a.hi), acos(a.lo))
-end
-
-
-function atan(a::Interval{Float64})
+function atan{T}(a::Interval{T})
     isempty(a) && return a
 
     Interval(atan(a.lo, RoundDown), atan(a.hi, RoundUp))
 end
 
-function atan(a::Interval{BigFloat})
-    isempty(a) && return a
 
-    @controlled_round(BigFloat, atan(a.lo), atan(a.hi))
-end
-
-
-atan2{T<:Real, S<:Real}(y::Interval{T}, x::Interval{S}) = atan2(promote(y, x)...)
+#atan2{T<:Real, S<:Real}(y::Interval{T}, x::Interval{S}) = atan2(promote(y, x)...)
 
 function atan2(y::Interval{Float64}, x::Interval{Float64})
     (isempty(y) || isempty(x)) && return emptyinterval(Float64)
-    res = with_bigfloat_precision(53) do
-        atan2( Interval(big(y.lo), big(y.hi)), Interval(big(x.lo), big(x.hi)))
-    end
-    float(res)
+
+    to_float(atan2(big53(y), big53(x)))
 end
 
 function atan2(y::Interval{BigFloat}, x::Interval{BigFloat})

--- a/src/root_finding/krawczyk.jl
+++ b/src/root_finding/krawczyk.jl
@@ -6,7 +6,7 @@
 
  doc"""Returns two intervals, the first being a point within the
 interval x such that the interval corresponding to the derivative of f there
-does not contain zero, and the second is the inverse of its derivative""" ->
+does not contain zero, and the second is the inverse of its derivative"""
 function guarded_derivative_midpoint{T}(f::Function, f_prime::Function, x::Interval{T})
 
     α = convert(T, 0.46875)   # close to 0.5, but exactly representable as a floating point

--- a/src/root_finding/krawczyk.jl
+++ b/src/root_finding/krawczyk.jl
@@ -4,7 +4,7 @@
 
 # const D = differentiate
 
-@doc doc"""Returns two intervals, the first being a point within the
+ doc"""Returns two intervals, the first being a point within the
 interval x such that the interval corresponding to the derivative of f there
 does not contain zero, and the second is the inverse of its derivative""" ->
 function guarded_derivative_midpoint{T}(f::Function, f_prime::Function, x::Interval{T})

--- a/src/root_finding/newton.jl
+++ b/src/root_finding/newton.jl
@@ -3,7 +3,7 @@
 # Newton method
 
 # What is this guarded_mid for? Shouldn't it be checking if f(m)==0?
-@doc doc"""Returns the midpoint of the interval x, slightly shifted in case
+ doc"""Returns the midpoint of the interval x, slightly shifted in case
 it is zero""" ->
 function guarded_mid{T}(x::Interval{T})
     m = mid(x)
@@ -26,7 +26,7 @@ function N{T}(f::Function, x::Interval{T}, deriv::Interval{T})
 end
 
 
-@doc doc"""If a root is known to be inside an interval,
+ doc"""If a root is known to be inside an interval,
 `newton_refine` iterates the interval Newton method until that root is found.""" ->
 function newton_refine{T}(f::Function, f_prime::Function, x::Interval{T};
                           tolerance=eps(T), debug=false)
@@ -53,7 +53,7 @@ end
 
 
 
-@doc doc"""`newton` performs the interval Newton method on the given function `f`
+ doc"""`newton` performs the interval Newton method on the given function `f`
 with its optional derivative `f_prime` and initial interval `x`.
 Optional keyword arguments give the `tolerance`, `maxlevel` at which to stop
 subdividing, and a `debug` boolean argument that prints out diagnostic information.""" ->

--- a/src/root_finding/newton.jl
+++ b/src/root_finding/newton.jl
@@ -4,7 +4,7 @@
 
 # What is this guarded_mid for? Shouldn't it be checking if f(m)==0?
  doc"""Returns the midpoint of the interval x, slightly shifted in case
-it is zero""" ->
+it is zero"""
 function guarded_mid{T}(x::Interval{T})
     m = mid(x)
     if m == zero(T)                     # midpoint exactly 0
@@ -27,7 +27,7 @@ end
 
 
  doc"""If a root is known to be inside an interval,
-`newton_refine` iterates the interval Newton method until that root is found.""" ->
+`newton_refine` iterates the interval Newton method until that root is found."""
 function newton_refine{T}(f::Function, f_prime::Function, x::Interval{T};
                           tolerance=eps(T), debug=false)
 
@@ -56,7 +56,7 @@ end
  doc"""`newton` performs the interval Newton method on the given function `f`
 with its optional derivative `f_prime` and initial interval `x`.
 Optional keyword arguments give the `tolerance`, `maxlevel` at which to stop
-subdividing, and a `debug` boolean argument that prints out diagnostic information.""" ->
+subdividing, and a `debug` boolean argument that prints out diagnostic information."""
 
 function newton{T}(f::Function, f_prime::Function, x::Interval{T}, level::Int=0;
                    tolerance=eps(T), debug=false, maxlevel=30)

--- a/test/interval_tests/construct_tests.jl
+++ b/test/interval_tests/construct_tests.jl
@@ -11,11 +11,11 @@ facts("Constructing intervals") do
     set_interval_precision(Float64)
     @fact get_interval_precision() == (Float64,-1) --> true
 
-    # Checks for interval_parameters
-    @fact ValidatedNumerics.interval_parameters.precision_type --> Float64
-    @fact ValidatedNumerics.interval_parameters.precision --> 53
-    @fact ValidatedNumerics.interval_parameters.rounding --> :narrow
-    @fact ValidatedNumerics.interval_parameters.pi --> @biginterval(pi)
+    # Checks for parameters
+    @fact ValidatedNumerics.parameters.precision_type --> Float64
+    @fact ValidatedNumerics.parameters.precision --> 53
+    @fact ValidatedNumerics.parameters.rounding --> :narrow
+    @fact ValidatedNumerics.parameters.pi --> @biginterval(pi)
 
     # Naive constructors, with no conversion involved
     @fact Interval(1) --> Interval(1.0, 1.0)
@@ -127,5 +127,12 @@ facts("Constructing intervals") do
         @fact Interval(1//2) == Interval(0.5) --> true
         @fact Interval(1//10).lo == rationalize(0.1) --> true
     end
+
+    @test string(@interval(Inf)) == "∅"
+
+    params = IntervalParameters()
+    @test params.precision_type == BigFloat
+    @test params.precision == 256
+    @test params.rounding == :narrow
 
 end

--- a/test/interval_tests/construct_tests.jl
+++ b/test/interval_tests/construct_tests.jl
@@ -20,23 +20,27 @@ facts("Constructing intervals") do
     # Naive constructors, with no conversion involved
     @fact Interval(1) --> Interval(1.0, 1.0)
     @fact Interval(big(1)) --> Interval(1.0, 1.0)
-    @fact Interval(2,1) --> Interval(1.0, 2.0)
-    @fact Interval(big(2),big(1)) --> Interval(1.0, 2.0)
     @fact Interval(eu) --> Interval(1.0*eu)
     @fact Interval(1//10) --> Interval{Rational{Int}}(1//10, 1//10)
     @fact Interval(BigInt(1)//10) --> Interval{Rational{BigInt}}(1//10, 1//10)
-    @fact Interval(BigInt(1),1//10) --> Interval{Rational{BigInt}}(1//10, 1//1)
-    @fact Interval(1,0.1) --> Interval{Float64}(0.1, 1)
-    @fact Interval(big(1),big(0.1)) --> Interval{BigFloat}(0.1, 1)
     @fact Interval( (1.0, 2.0) ) --> Interval(1.0, 2.0)
-    # Constructors that involve convert methods; does not work in v0.3
-    if VERSION > v"0.4-"
-        @fact Interval{Rational{Int}}(1) --> Interval(1//1)
-        @fact Interval{Rational{Int}}(pi) --> Interval(rationalize(1.0*pi))
-        @fact Interval{BigFloat}(1) --> Interval{BigFloat}(big(1.0),big(1.0))
-        @fact Interval{BigFloat}(pi) -->
-            Interval{BigFloat}(big(3.1415926535897931), big(3.1415926535897936))
-    end
+
+    @fact Interval{Rational{Int}}(1) --> Interval(1//1)
+    @fact Interval{Rational{Int}}(pi) --> Interval(rationalize(1.0*pi))
+    @fact Interval{BigFloat}(1) --> Interval{BigFloat}(big(1.0),big(1.0))
+    @fact Interval{BigFloat}(pi) -->
+        Interval{BigFloat}(big(3.1415926535897931), big(3.1415926535897936))
+
+    # Disallowed conversions with a > b
+
+    @fact_throws ArgumentError Interval(2, 1)
+    @fact_throws ArgumentError Interval(big(2), big(1))
+    @fact_throws ArgumentError Interval(BigInt(1), 1//10)
+    @fact_throws ArgumentError Interval(1, 0.1)
+    @fact_throws ArgumentError Interval(big(1), big(0.1))
+
+
+
 
 
     # Conversions; may involve rounding

--- a/test/interval_tests/construct_tests.jl
+++ b/test/interval_tests/construct_tests.jl
@@ -128,11 +128,11 @@ facts("Constructing intervals") do
         @fact Interval(1//10).lo == rationalize(0.1) --> true
     end
 
-    @test string(@interval(Inf)) == "∅"
+    @fact string(emptyinterval()) == "∅" --> true
 
-    params = IntervalParameters()
-    @test params.precision_type == BigFloat
-    @test params.precision == 256
-    @test params.rounding == :narrow
+    params = ValidatedNumerics.IntervalParameters()
+    @fact params.precision_type == BigFloat --> true
+    @fact params.precision == 256 --> true
+    @fact params.rounding == :narrow --> true
 
 end

--- a/test/interval_tests/numeric_tests.jl
+++ b/test/interval_tests/numeric_tests.jl
@@ -75,7 +75,7 @@ facts("Numeric tests") do
     @fact @interval(1,27)^@interval(1/3) --> roughly(Interval(1., 3.))
     @fact @interval(1,27)^(1/3) --> Interval(1., 3.)
     @fact @interval(1,27)^(1//3) --> Interval(1., 3.)
-    @fact @interval(0.1,0.7)^(1//3) --> Interval(0.4641588833612778, 0.887904001742601)
+    @fact @interval(0.1,0.7)^(1//3) --> Interval(0.46415888336127786, 0.8879040017426009)
     @fact @interval(0.1,0.7)^(1/3)  --> roughly(Interval(0.46415888336127786, 0.8879040017426008))
 
 
@@ -158,18 +158,16 @@ facts("Numeric tests") do
     @fact round(@interval(-1.5, 0.1), RoundTiesToAway) --> Interval(-2.0, 0.0)
     @fact round(@interval(-2.5, 0.1), RoundTiesToAway) --> Interval(-3.0, 0.0)
 
-    @fact_throws ArgumentError round(@interval(0.1, -2.5))
-
     # :wide tests
     set_interval_rounding(:wide)
     set_interval_precision(Float64)
 
     a = @interval(-3.0, 2.0)
     @fact a --> Interval(prevfloat(-3.0), nextfloat(2.0))
-    @fact a^3 --> Interval(prevfloat(a.lo^3), nextfloat(a.hi^3))
-    @fact Interval(-3,2)^3 --> Interval(prevfloat(-27.0), nextfloat(8.0))
+    @fact a^3 --> Interval(-27.00000000000003, 8.000000000000012)
+    @fact Interval(-3,2)^3 --> Interval(-27.000000000000014, 8.000000000000007)
 
-    @fact Interval(-27.0, 8.0)^(1//3) --> Interval(-1.0e-323, 2.0000000000000013)
+    @fact Interval(-27.0, 8.0)^(1//3) --> Interval(-0.0, 2.0000000000000013)
 
     set_interval_rounding(:narrow)
 end

--- a/test/interval_tests/numeric_tests.jl
+++ b/test/interval_tests/numeric_tests.jl
@@ -80,7 +80,6 @@ facts("Numeric tests") do
 
 
     # exp and log
-    x = prevfloat(Inf)
     @fact exp(@biginterval(1//2)) ⊆ exp(@interval(1//2)) --> true
     @fact exp(@interval(1//2)) --> Interval(1.648721270700128, 1.6487212707001282)
     @fact exp(@biginterval(0.1)) ⊆ exp(@interval(0.1)) --> true
@@ -92,9 +91,9 @@ facts("Numeric tests") do
     @fact log(@interval(0.1)) --> Interval(-2.3025850929940459e+00, -2.3025850929940455e+00)
     @fact diam(log(@interval(0.1))) --> eps(log(0.1))
     @fact exp2(@biginterval(1//2)) ⊆ exp2(@interval(1//2)) --> true
-    @fact exp2(Interval(1024.0)) --> Interval(x, Inf)
+    @fact exp2(Interval(1024.0)) --> Interval(Inf, Inf)
     @fact exp10(@biginterval(1//2)) ⊆ exp10(@interval(1//2)) --> true
-    @fact exp10(Interval(308.5)) --> Interval(x, Inf)
+    @fact exp10(Interval(308.5)) --> Interval(Inf, Inf)
     @fact log2(@biginterval(1//2)) ⊆ log2(@interval(1//2)) --> true
     @fact log2(@interval(0.25, 0.5)) --> Interval(-2.0, -1.0)
     @fact log10(@biginterval(1//10)) ⊆ log10(@interval(1//10)) --> true

--- a/test/interval_tests/numeric_tests.jl
+++ b/test/interval_tests/numeric_tests.jl
@@ -53,7 +53,7 @@ facts("Numeric tests") do
     @fact Interval(1,2) ^ -3 --> Interval(1/8, 1.0)
     @fact Interval(0,3) ^ -3 --> @interval(1/27, Inf)
     @fact Interval(-1,2) ^ -3 --> entireinterval()
-    @fact Interval(-1,-2) ^ -3 --> Interval(-1.0, -1/8)
+    @fact_throws ArgumentError Interval(-1, -2) ^ -3  # wrong way round
     @fact Interval(-3,2) ^ (3//1) --> Interval(-27, 8)
     @fact Interval(0.0) ^ 1.1 --> Interval(0, 0)
     @fact Interval(0.0) ^ 0.0 --> emptyinterval()
@@ -147,16 +147,18 @@ facts("Numeric tests") do
     @fact round(@interval(0.1, 1.1), RoundToZero) --> Interval(0.0, 1.0)
     @fact round(@interval(0.1, 1.1)) --> Interval(0.0, 1.0)
     @fact round(@interval(0.1, 1.5)) --> Interval(0.0, 2.0)
-    @fact round(@interval(0.1, -1.5)) --> Interval(0.0, -2.0)
-    @fact round(@interval(0.1, -2.5)) --> Interval(0.0, -2.0)
+    @fact round(@interval(-1.5, 0.1)) --> Interval(-2.0, 0.0)
+    @fact round(@interval(-2.5, 0.1)) --> Interval(-2.0, 0.0)
     @fact round(@interval(0.1, 1.1), RoundTiesToEven) --> Interval(0.0, 1.0)
     @fact round(@interval(0.1, 1.5), RoundTiesToEven) --> Interval(0.0, 2.0)
-    @fact round(@interval(0.1, -1.5), RoundTiesToEven) --> Interval(0.0, -2.0)
-    @fact round(@interval(0.1, -2.5), RoundTiesToEven) --> Interval(0.0, -2.0)
+    @fact round(@interval(-1.5, 0.1), RoundTiesToEven) --> Interval(-2.0, 0.0)
+    @fact round(@interval(-2.5, 0.1), RoundTiesToEven) --> Interval(-2.0, 0.0)
     @fact round(@interval(0.1, 1.1), RoundTiesToAway) --> Interval(0.0, 1.0)
     @fact round(@interval(0.1, 1.5), RoundTiesToAway) --> Interval(0.0, 2.0)
-    @fact round(@interval(0.1, -1.5), RoundTiesToAway) --> Interval(0.0, -2.0)
-    @fact round(@interval(0.1, -2.5), RoundTiesToAway) --> Interval(0.0, -3.0)
+    @fact round(@interval(-1.5, 0.1), RoundTiesToAway) --> Interval(-2.0, 0.0)
+    @fact round(@interval(-2.5, 0.1), RoundTiesToAway) --> Interval(-3.0, 0.0)
+
+    @fact_throws ArgumentError round(@interval(0.1, -2.5))
 
     # :wide tests
     set_interval_rounding(:wide)

--- a/test/interval_tests/numeric_tests.jl
+++ b/test/interval_tests/numeric_tests.jl
@@ -85,15 +85,18 @@ facts("Numeric tests") do
     @fact exp(@biginterval(0.1)) ⊆ exp(@interval(0.1)) --> true
     @fact exp(@interval(0.1)) --> Interval(1.1051709180756475e+00, 1.1051709180756477e+00)
     @fact diam(exp(@interval(0.1))) --> eps(exp(0.1))
+
     @fact log(@biginterval(1//2)) ⊆ log(@interval(1//2)) --> true
     @fact log(@interval(1//2)) --> Interval(-6.931471805599454e-01, -6.9314718055994529e-01)
     @fact log(@biginterval(0.1)) ⊆ log(@interval(0.1)) --> true
     @fact log(@interval(0.1)) --> Interval(-2.3025850929940459e+00, -2.3025850929940455e+00)
     @fact diam(log(@interval(0.1))) --> eps(log(0.1))
+
     @fact exp2(@biginterval(1//2)) ⊆ exp2(@interval(1//2)) --> true
     @fact exp2(Interval(1024.0)) --> Interval(Inf, Inf)
     @fact exp10(@biginterval(1//2)) ⊆ exp10(@interval(1//2)) --> true
     @fact exp10(Interval(308.5)) --> Interval(Inf, Inf)
+
     @fact log2(@biginterval(1//2)) ⊆ log2(@interval(1//2)) --> true
     @fact log2(@interval(0.25, 0.5)) --> Interval(-2.0, -1.0)
     @fact log10(@biginterval(1//10)) ⊆ log10(@interval(1//10)) --> true

--- a/test/misc_tests.jl
+++ b/test/misc_tests.jl
@@ -14,11 +14,8 @@ facts("Rationalize tests") do
             1 / 10
         end
 
-        println("Rationalizing a=$a")
+        #println("Rationalizing a=$a")
         @fact ValidatedNumerics.old_rationalize(a) == 1//10 --> true
 
     end
 end
-
-
-


### PR DESCRIPTION
Rewrite to use functions of the form `sin(x::BigFloat, RoundDown)` when possible.
Rewrite `^` to convert `Float64` intervals straight into `BigFloat` intervals.

Introduces `big53` and `to_float` functions to convert `Float64` to `BigFloat` intervals and back.

Also some other clean-up and docs.

`@controlled_round` is now no longer used.