### PR TITLE
RFC: Add display mode capability

### DIFF
--- a/src/ValidatedNumerics.jl
+++ b/src/ValidatedNumerics.jl
@@ -41,7 +41,7 @@ export
     .., @I_str, ±
 
 export
-    display_mode
+    displaymode
 
 if VERSION >= v"0.5.0-dev+1182"
     import Base: rounding, setrounding, setprecision

--- a/src/ValidatedNumerics.jl
+++ b/src/ValidatedNumerics.jl
@@ -40,6 +40,9 @@ export
     cancelminus, cancelplus, isunbounded,
     .., @I_str, ±
 
+export
+    display_mode
+
 if VERSION >= v"0.5.0-dev+1182"
     import Base: rounding, setrounding, setprecision
 else

--- a/src/ValidatedNumerics.jl
+++ b/src/ValidatedNumerics.jl
@@ -11,7 +11,7 @@ using FixedSizeArrays
 import Base:
     +, -, *, /, //, fma,
     <, >, ==, !=, ⊆, ^, <=,
-    in, zero, one, abs, real, show, min, max,
+    in, zero, one, abs, real, min, max,
     sqrt, exp, log, sin, cos, tan, inv,
     exp2, exp10, log2, log10,
     asin, acos, atan, atan2,
@@ -23,7 +23,8 @@ import Base:
     floor, ceil, trunc, sign, round,
     expm1, log1p,
     precision,
-    isfinite, isnan
+    isfinite, isnan,
+    show, showall
 
 export
     Interval, AbstractInterval,

--- a/src/ValidatedNumerics.jl
+++ b/src/ValidatedNumerics.jl
@@ -84,6 +84,8 @@ include("intervals/intervals.jl")
 include("multidim/multidim.jl")
 include("decorations/decorations.jl")
 
+include("display.jl")
+
 include("root_finding/root_finding.jl")
 
 

--- a/src/decorations/intervals.jl
+++ b/src/decorations/intervals.jl
@@ -19,7 +19,7 @@ The nomenclature of the follows the IEEE-1788 (2015) standard
 # Note that `isless`, and hence ``<` and `min`, are automatically defined for enums
 
 """
-DecoratedInterval
+    DecoratedInterval
 
 A `DecoratedInterval` is an interval, together with a *decoration*, i.e.
 a flag that records the status of the interval when thought of as the result
@@ -84,7 +84,7 @@ function convert{T<:Real}(::Type{DecoratedInterval{T}}, xx::DecoratedInterval)
 end
 
 
-show(io::IO, x::DecoratedInterval) = print(io, x.interval, "_", x.decoration)
+# show(io::IO, x::DecoratedInterval) = print(io, x.interval, "_", x.decoration)
 
 macro decorated(ex...)
     local x

--- a/src/display.jl
+++ b/src/display.jl
@@ -8,7 +8,7 @@ const display_params = DisplayParameters(:standard, false, 6)
 
 
 
-function display_mode(;decorations=nothing, interval_display=nothing, precision::Int=-1)
+function display_mode(;decorations=nothing, interval_display=nothing, precision=-1)
     if interval_display != nothing
         display_params.interval_display = interval_display
     end
@@ -19,18 +19,31 @@ function display_mode(;decorations=nothing, interval_display=nothing, precision:
 
     if precision >= 0
         display_params.precision = precision
+        change_precision(precision)
     end
 end
 
 
-function format(x::Float64, prec::Int)
-    fmt = "%.$(prec)g"
-    @eval @sprintf($fmt, $x)
-    # hack from https://github.com/JuliaLang/julia/issues/4248
-    # Replace with Formatting.jl if supports %g
-end
 
-format(x::Float64) = format(x, display_params.precision)
+## Output
+
+function change_precision(prec::Int)
+    prec = Float64(prec)
+    prec = Int(prec)
+    #display_params.float_format = "%.$(prec)g"
+    fmt = "%.$(prec)g"
+    @eval format(x::Float64) = (@sprintf($fmt, x))
+    # creates global "format" function; add to __init__
+end
+change_precision(6)  # move to __init__
+
+
+# function format(x::Float64, prec::Int)
+#     fmt = "%.$(prec)g"
+#     @eval @sprintf($fmt, $x)
+# end
+#
+# format(x::Float64) = format(x, display_params.precision)
 
 function representation(a::Interval)
     if isempty(a)
@@ -42,10 +55,22 @@ function representation(a::Interval)
     local output
 
     if interval_display == :standard
-        aa = format(a.lo)
-        bb = format(a.hi)
+        #aa = format(a.lo)
+        #bb = format(a.hi)
 
-        output = "[$aa, $bb]"
+        # the following is a hack to make sure that format is not inlined:
+        # make it type unstable
+        aa = rand() < 2 ? a.lo : nothing
+        bb = rand() < 2 ? a.hi : nothing
+
+        aaa = format(aa)
+        bbb = format(bb)
+        #output = "[$(@noinline format(a.lo)), $(@noinline format(a.hi))]"
+        output = "[$aaa, $bbb]"
+        # prec = display_params.precision
+        # fmt = "[%.$(prec)g, %.$(prec)g]"
+        # output = @eval @sprintf($fmt, $(a.lo), $(a.hi))
+
         output = replace(output, "inf", "∞")
         output = replace(output, "Inf", "∞")
 

--- a/src/display.jl
+++ b/src/display.jl
@@ -1,0 +1,63 @@
+type DisplayParameters
+    interval_display::Symbol
+    decorations::Bool
+end
+
+const display_params = DisplayParameters(:standard, false)
+
+
+function display_mode(;decorations=nothing, interval_display=nothing)
+    if interval_display != nothing
+        display_params.interval_display = interval_display
+    end
+
+    if decorations != nothing
+        display_params.decorations = decorations
+    end
+end
+
+
+
+## Output
+
+function representation(a::Interval)
+    if isempty(a)
+        return "∅"
+    end
+
+    interval_display = display_params.interval_display
+
+    local output
+
+    if interval_display == :standard
+        output = "[$(a.lo), $(a.hi)]"
+        output = replace(output, "inf", "∞")
+        output = replace(output, "Inf", "∞")
+
+    elseif interval_display == :reproducible
+        output = "Interval($(a.lo), $(a.hi))"
+
+    elseif interval_display == :midpoint_radius
+        output = "$(mid(a)) ± $(diam(a)/2)"
+    end
+
+    output
+end
+
+function representation(a::Interval{BigFloat})
+    if interval_display == :standard
+        string( invoke(representation, (Interval,), a),
+                    subscriptify(precision(a.lo)) )
+
+    elseif interval_display == :reproducible
+        invoke(representation, (Interval,), a)
+    end
+end
+
+show(io::IO, a::Interval) = print(io, representation(a))
+
+function subscriptify(n::Int)
+    subscript_digits = [c for c in "₀₁₂₃₄₅₆₇₈₉"]
+    dig = reverse(digits(n))
+    join([subscript_digits[i+1] for i in dig])
+end

--- a/src/display.jl
+++ b/src/display.jl
@@ -56,12 +56,15 @@ end
 round_string(x::Real, digits::Int, r::RoundingMode) = round_string(big(x), digits, r)
 
 
-function representation(a::Interval)
+function representation(a::Interval, format=nothing)
     if isempty(a)
         return "∅"
     end
 
-    format = display_params.format
+    if format == nothing
+        format = display_params.format  # default
+    end
+
     sigfigs = display_params.sigfigs
 
     local output
@@ -115,6 +118,8 @@ end
 
 show(io::IO, a::Interval) = print(io, representation(a))
 show(io::IO, a::DecoratedInterval) = print(io, representation(a))
+
+showall(io::IO, a::Interval) = print(io, representation(a, :full))
 
 function subscriptify(n::Int)
     subscript_digits = [c for c in "₀₁₂₃₄₅₆₇₈₉"]

--- a/src/display.jl
+++ b/src/display.jl
@@ -1,12 +1,14 @@
 type DisplayParameters
     interval_display::Symbol
     decorations::Bool
+    precision::Int
 end
 
-const display_params = DisplayParameters(:standard, false)
+const display_params = DisplayParameters(:standard, false, 6)
 
 
-function display_mode(;decorations=nothing, interval_display=nothing)
+
+function display_mode(;decorations=nothing, interval_display=nothing, precision::Int=-1)
     if interval_display != nothing
         display_params.interval_display = interval_display
     end
@@ -14,11 +16,21 @@ function display_mode(;decorations=nothing, interval_display=nothing)
     if decorations != nothing
         display_params.decorations = decorations
     end
+
+    if precision >= 0
+        display_params.precision = precision
+    end
 end
 
 
+function format(x::Float64, prec::Int)
+    fmt = "%.$(prec)g"
+    @eval @sprintf($fmt, $x)
+    # hack from https://github.com/JuliaLang/julia/issues/4248
+    # Replace with Formatting.jl if supports %g
+end
 
-## Output
+format(x::Float64) = format(x, display_params.precision)
 
 function representation(a::Interval)
     if isempty(a)
@@ -30,7 +42,10 @@ function representation(a::Interval)
     local output
 
     if interval_display == :standard
-        output = "[$(a.lo), $(a.hi)]"
+        aa = format(a.lo)
+        bb = format(a.hi)
+
+        output = "[$aa, $bb]"
         output = replace(output, "inf", "∞")
         output = replace(output, "Inf", "∞")
 

--- a/src/display.jl
+++ b/src/display.jl
@@ -94,6 +94,17 @@ function representation(a::Interval{BigFloat})
     end
 end
 
+function representation(a::DecoratedInterval)
+    interval_part = representation(interval_part(a))
+
+    if display_params.decorations
+        string(interval_part, decoration(a))
+    else
+        interval_part
+    end
+
+end
+
 show(io::IO, a::Interval) = print(io, representation(a))
 
 function subscriptify(n::Int)

--- a/src/display.jl
+++ b/src/display.jl
@@ -6,11 +6,13 @@ end
 
 const display_params = DisplayParameters(:standard, false, 6)
 
+const display_options = [:standard, :full, :midpoint]
 
 doc"""
     displaymode(;kw)
 
-`displaymode` changes how intervals are displayed using keyword arguments. Options:
+`displaymode` changes how intervals are displayed using keyword arguments.
+The following options are available:
 
 - `format`: interval output format
 
@@ -24,7 +26,13 @@ doc"""
 """
 function displaymode(;decorations=nothing, format=nothing, sigfigs=-1)
     if format != nothing
-        display_params.format = format
+
+        if format in display_options
+            display_params.format = format
+        else
+            throw(ArgumentError("Allowed format option is one of  $display_options."))
+        end
+
     end
 
     if decorations != nothing

--- a/src/display.jl
+++ b/src/display.jl
@@ -95,17 +95,18 @@ function representation(a::Interval{BigFloat})
 end
 
 function representation(a::DecoratedInterval)
-    interval_part = representation(interval_part(a))
+    interval = representation(interval_part(a))
 
     if display_params.decorations
-        string(interval_part, decoration(a))
+        string(interval, "_", decoration(a))
     else
-        interval_part
+        interval
     end
 
 end
 
 show(io::IO, a::Interval) = print(io, representation(a))
+show(io::IO, a::DecoratedInterval) = print(io, representation(a))
 
 function subscriptify(n::Int)
     subscript_digits = [c for c in "₀₁₂₃₄₅₆₇₈₉"]

--- a/src/intervals/intervals.jl
+++ b/src/intervals/intervals.jl
@@ -58,30 +58,4 @@ macro I_str(ex)  # I"[3,4]"
     @interval(ex)
 end
 
-a ± b = (a-b)..(a+b)  
-
-
-## Output
-
-function basic_show(io::IO, a::Interval)
-    if isempty(a)
-        output = "∅"
-    else
-        output = "[$(a.lo), $(a.hi)]"
-        output = replace(output, "inf", "∞")
-        output = replace(output, "Inf", "∞")
-
-        output
-    end
-
-    print(io, output)
-end
-
-show(io::IO, a::Interval) = basic_show(io, a)
-show(io::IO, a::Interval{BigFloat}) = ( basic_show(io, a); print(io, subscriptify(precision(a.lo))) )
-
-function subscriptify(n::Int)
-    subscript_digits = [c for c in "₀₁₂₃₄₅₆₇₈₉"]
-    dig = reverse(digits(n))
-    join([subscript_digits[i+1] for i in dig])
-end
+a ± b = (a-b)..(a+b)

--- a/test/display_tests/display.jl
+++ b/test/display_tests/display.jl
@@ -1,0 +1,87 @@
+
+using ValidatedNumerics
+using FactCheck
+
+setprecision(Interval, Float64)
+
+facts("displaymode tests") do
+
+    context("Interval") do
+
+        a = 1..2
+        b = -1.1..1.3
+        c = Interval(pi)
+        d = @interval(π)
+
+        context("6 sig figs") do
+            displaymode(format=:standard, sigfigs=6)
+
+            @fact string(a) --> "[1, 2]"
+            @fact string(b) --> "[-1.10001, 1.30001]"
+            @fact string(c) --> "[3.14159, 3.1416]"
+            @fact string(d) --> "[3.14159, 3.1416]"
+        end
+
+        context("10 sig figs") do
+            displaymode(sigfigs=10)
+
+            @fact string(a) --> "[1, 2]"
+            @fact string(b) --> "[-1.100000001, 1.300000001]"
+            @fact string(c) --> "[3.141592653, 3.141592654]"
+            @fact string(d) --> "[3.141592653, 3.141592654]"
+        end
+
+        context("20 sig figs") do
+            displaymode(sigfigs=20)
+
+            @fact string(a) --> "[1, 2]"
+            @fact string(b) --> "[-1.1000000000000000889, 1.3000000000000000445]"
+            @fact string(c) --> "[3.1415926535897931159, 3.141592653589793116]"
+            @fact string(d) --> "[3.1415926535897931159, 3.1415926535897935601]"
+        end
+
+        context("Full") do
+            displaymode(format=:full)
+
+            @fact string(a) --> "Interval(1.0, 2.0)"
+            @fact string(b) --> "Interval(-1.1, 1.3)"
+            @fact string(c) --> "Interval(3.141592653589793, 3.141592653589793)"
+            @fact string(d) --> "Interval(3.141592653589793, 3.1415926535897936)"
+        end
+
+        context("Midpoint") do
+            displaymode(format=:midpoint, sigfigs=6)
+
+            @fact string(a) --> "1.5 ± 0.5"
+            @fact string(b) --> "0.1 ± 1.20001"
+            @fact string(c) --> "3.14159 ± 0"
+            @fact string(d) --> "3.14159 ± 4.4409e-16"
+        end
+
+
+    end
+
+    context("DecoratedInterval") do
+        a = @decorated(1, 2)
+
+        displaymode(format=:standard, decorations=false)
+
+        @fact string(a) --> "[1, 2]"
+
+        displaymode(format=:standard, decorations=true)
+
+        @fact string(a) --> "[1, 2]_com"
+
+    end
+
+    context("IntervalBox") do
+        displaymode(sigfigs=6)
+
+        X = IntervalBox(1..2, 3..4)
+        @fact string(X) --> "[1, 2] × [3, 4]"
+
+        X = IntervalBox(1.1..1.2, 2.1..2.2)
+        @fact string(X) --> "[1.09999, 1.20001] × [2.09999, 2.20001]"
+
+    end
+end

--- a/test/multidim_tests/multidim.jl
+++ b/test/multidim_tests/multidim.jl
@@ -37,9 +37,4 @@ facts("@intervalbox tests") do
     @fact isa(g(X), IntervalBox) --> true
 
 
-    setprecision(Interval, Float64)
-
-    X = IntervalBox(1..1, 2..2)
-    @fact string(X) --> "[1.0, 1.0] × [2.0, 2.0]"
-
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,11 +14,13 @@ include("interval_tests/intervals.jl")
 include("multidim_tests/multidim.jl")
 include("decoration_tests/decoration_tests.jl")
 
+# Display tests:
+include("display_tests/display.jl")
+
 # Root-finding tests:
 
 include("root_finding_tests/root_finding.jl")
 
-# Multidimensional boxes tests:
 
 # ITF1788 tests
 


### PR DESCRIPTION
The idea is to be able to do the following. Of course, the syntax etc. is not nice at the moment.
We can add output precision, output or not decorations, etc.

```julia
julia> a = Interval(3, 4)
[3.0, 4.0]

julia> displaymode(format=:full)

julia> a
Interval(3.0, 4.0)

julia> displaymode(format=:midpoint)

julia> a
3.5 ± 0.5
```

Now it also does the following:
```julia
julia> a = @decorated(1)
[1, 1]

julia> a = @decorated(-pi, pi)
[-3.1416, 3.1416]

julia> displaymode(sigfigs=10)

julia> a
[-3.141592654, 3.141592654]

julia> displaymode(decorations=true)

julia> a
[-3.141592654, 3.141592654]_com
```