### PR TITLE
Deal with updates in derivative (ForwardDiff v0.2)

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -2,4 +2,4 @@ julia 0.4
 CRlibm 0.2.2
 Compat 0.7.11
 FixedSizeArrays 0.1.2
-ForwardDiff 0.1.8
+ForwardDiff 0.2.0

--- a/src/root_finding/krawczyk.jl
+++ b/src/root_finding/krawczyk.jl
@@ -96,17 +96,14 @@ end
 
 # use automatic differentiation if no derivative function given
 krawczyk{T}(f::Function,x::Interval{T}; args...) =
-    krawczyk(f, D(f), x; args...)
+    krawczyk(f, x->D(f,x), x; args...)
 
 # krawczyk for vector of intervals:
 krawczyk{T}(f::Function, f_prime::Function, xx::Vector{Interval{T}}; args...) =
-
     vcat([krawczyk(f, f_prime, @interval(x); args...) for x in xx]...)
 
 krawczyk{T}(f::Function,  xx::Vector{Interval{T}}, level; args...) =
-
-    krawczyk(f, D(f), xx; args...)
+    krawczyk(f, x->D(f,x), xx; args...)
 
 krawczyk{T}(f::Function,  xx::Vector{Root{T}}; args...) =
-
-    krawczyk(f, D(f), [x.interval for x in xx]; args...)
+    krawczyk(f, x->D(f,x), [x.interval for x in xx]; args...)

--- a/src/root_finding/newton.jl
+++ b/src/root_finding/newton.jl
@@ -134,19 +134,15 @@ end
 
 
 # use automatic differentiation if no derivative function given:
-newton{T}(f::Function, x::Interval{T};  args...) = newton(f, D(f), x; args...)
-
-
+newton{T}(f::Function, x::Interval{T};  args...) =
+    newton(f, x->D(f,x), x; args...)
 
 # newton for vector of intervals:
 newton{T}(f::Function, f_prime::Function, xx::Vector{Interval{T}}; args...) =
-
     vcat([newton(f, f_prime, @interval(x); args...) for x in xx]...)
 
 newton{T}(f::Function,  xx::Vector{Interval{T}}, level; args...) =
-
-    newton(f, D(f), xx, 0, args...)
+    newton(f, x->D(f,x), xx, 0, args...)
 
 newton{T}(f::Function,  xx::Vector{Root{T}}; args...) =
-
-    newton(f, D(f), [x.interval for x in xx], args...)
+    newton(f, x->D(f,x), [x.interval for x in xx], args...)

--- a/src/root_finding/root_finding.jl
+++ b/src/root_finding/root_finding.jl
@@ -2,7 +2,8 @@
 
 using ForwardDiff
 
-const D = ForwardDiff.derivative
+const derivative = ForwardDiff.derivative
+const D = derivative
 
 immutable Root{T<:Real}
     interval::Interval{T}

--- a/test/root_finding_tests/root_finding.jl
+++ b/test/root_finding_tests/root_finding.jl
@@ -41,11 +41,11 @@ three_halves_pi = 3*big_pi/2
 # Format:  (function, derivative, lower_bound, upper_bound, [true_roots])
 function_list = [
                     (sin, cos,    -5,  5,    [ -big_pi, @interval(0), big_pi ] ) ,
-                    (cos, D(cos), -7.5, 7.5, [ -three_halves_pi, -half_pi, half_pi, three_halves_pi ] ),
-                    (W₃, D(W₃),   -10, 10,   [ @interval(1), @interval(2), @interval(3) ] ),
-                    (W₇, D(W₇),   -10, 10,   [ @interval(i) for i in 1:7 ] ),
-                    (x->exp(x)-2, D(x->exp(x)),  -20, 20,  [log(@biginterval(2))] ),
-                    (x->asin(sin(x)) - 0.1, D(x->asin(sin(x))), 0, 1, [@biginterval(0.1)])
+                    (cos, x->D(cos, x), -7.5, 7.5, [ -three_halves_pi, -half_pi, half_pi, three_halves_pi ] ),
+                    (W₃, x->D(W₃, x),   -10, 10,   [ @interval(1), @interval(2), @interval(3) ] ),
+                    (W₇, x->D(W₇, x),   -10, 10,   [ @interval(i) for i in 1:7 ] ),
+                    (x->exp(x)-2, y->D(x->exp(x),y),  -20, 20,  [log(@biginterval(2))] ),
+                    (x->asin(sin(x)) - 0.1, y->D(x->asin(sin(x)),y), 0, 1, [@biginterval(0.1)])
                 ]
 
 


### PR DESCRIPTION
@dpsanders Updates the syntax changed by ForwardDiff v0.2 in `derivative` which were breaking the root-finding tests; see #147.