### PR TITLE
Reenable tests for ITF-1788 for v0.5

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,9 +24,7 @@ include("root_finding_tests/root_finding.jl")
 
 # ITF1788 tests
 
-if VERSION < v"0.5-dev"
-    include("ITF1788_tests/ITF1788_tests.jl")
-end
+include("ITF1788_tests/ITF1788_tests.jl")
 
 FactCheck.exitstatus()
 


### PR DESCRIPTION
These tests were disabled a long back, simply because they were
taking too long to complete, so travis was complaning.