### PR TITLE
Proper display for Interval{Rational{T}}

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ os:
 
 julia:
   - 0.4
+  - 0.5
   - nightly
 
 notifications:

--- a/src/display.jl
+++ b/src/display.jl
@@ -98,7 +98,31 @@ function representation(a::Interval, format=nothing)
     output
 end
 
+function representation{T<:Integer}(a::Interval{Rational{T}},
+    format=nothing)
 
+    if isempty(a)
+        return "∅"
+    end
+
+    if format == nothing
+        format = display_params.format  # default
+    end
+    
+    local output
+
+    if format == :standard
+        output = "[$(a.lo), $(a.hi)]"
+    elseif format == :full
+        output = "Interval($(a.lo), $(a.hi))"
+    elseif format == :midpoint
+        m = mid(a)
+        r = radius(a)
+        output = "$m ± $r"
+    end
+
+    output
+end
 
 function subscriptify(n::Int)
     dig = reverse(digits(n))

--- a/test/display_tests/display.jl
+++ b/test/display_tests/display.jl
@@ -61,6 +61,18 @@ facts("displaymode tests") do
 
     end
 
+    context("Interval{Rational{T}}") do
+        a = Interval(1//3, 5//4)
+        displaymode(format=:standard)
+        @fact string(a) --> "[1//3, 5//4]"
+
+        displaymode(format=:full)
+        @fact string(a) --> "Interval(1//3, 5//4)"
+
+        displaymode(format=:midpoint)
+        @fact string(a) --> "19//24 ± 11//24"
+    end
+
     context("DecoratedInterval") do
         a = @decorated(1, 2)
 


### PR DESCRIPTION
Currently, in master, we get the following:
```julia
julia> using ValidatedNumerics

julia> Interval(1//2, 2//3)
Error showing value of type ValidatedNumerics.Interval{Rational{Int64}}:
ERROR: StackOverflowError:
 in BigInt() at ./gmp.jl:46
 in gcd at ./gmp.jl:255 [inlined]
 in Rational{BigInt}(::BigInt, ::BigInt) at ./rational.jl:9
 in round_string(::Rational{BigInt}, ::Int64, ::RoundingMode{:Down}) at /Users/benet/.julia/v0.5/ValidatedNumerics/src/display.jl:64 (repeats 79993 times)
```

The problem is that it tries to compute the number of significant digits for this interval, which is meaningless for this case.

This PR solves this, so one gets:
```julia
julia> Interval(1//2, 2//3)
[1//2, 2//3]

julia> displaymode(format=:midpoint)

julia> Interval(1//2, 2//3)
7//12 ± 1//12
```