### PR TITLE
Add plot recipe for Plots.jl

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # What's new in ValidatedNumerics.jl
 
+## v0.6
+- Add a plot recipe for (only) 2D `IntervalBox`es using `RecipesBase.jl`.
+This enables plotting using `Plots.jl` via `plot(X)` or `plot([X, Y])`,
+i.e. individual `IntervalBox`es or of a `Vector` of `IntervalBox`es.
+
 
 ## v0.5
 - Root finding has been moved into a separate submodule

--- a/REQUIRE
+++ b/REQUIRE
@@ -3,3 +3,4 @@ CRlibm 0.2.2
 Compat 0.7.11
 FixedSizeArrays 0.1.2
 ForwardDiff 0.2.0
+RecipesBase 0.1.0

--- a/REQUIRE
+++ b/REQUIRE
@@ -3,4 +3,4 @@ CRlibm 0.2.2
 Compat 0.7.11
 FixedSizeArrays 0.1.2
 ForwardDiff 0.2.0
-RecipesBase 0.1.0
+RecipesBase

--- a/src/ValidatedNumerics.jl
+++ b/src/ValidatedNumerics.jl
@@ -91,6 +91,7 @@ include("display.jl")
 
 include("root_finding/root_finding.jl")
 
+include("plot_recipes/plot_recipes.jl")
 
 
 end # module ValidatedNumerics

--- a/src/ValidatedNumerics.jl
+++ b/src/ValidatedNumerics.jl
@@ -91,7 +91,9 @@ include("display.jl")
 
 include("root_finding/root_finding.jl")
 
+#if VERSION >= v"0.5"
 include("plot_recipes/plot_recipes.jl")
+#end
 
 
 end # module ValidatedNumerics

--- a/src/plot_recipes/plot_recipes.jl
+++ b/src/plot_recipes/plot_recipes.jl
@@ -1,0 +1,44 @@
+using RecipesBase
+
+# Plot a 2D IntervalBox:
+@recipe function f(xx::IntervalBox{2}) #; customcolor = :green, alpha=0.5)
+
+    (x, y) = xx
+
+    alpha --> 0.5
+    seriestype := :shape
+
+    x = [x.lo, x.hi, x.hi, x.lo]
+    y = [y.lo, y.lo, y.hi, y.hi]
+
+    x, y
+end
+
+# Plot a vector of 2D IntervalBoxes:
+@recipe function f{T<:IntervalBox{2}}(v::Vector{T})
+
+    seriestype := :shape
+
+    xs = Float64[]
+    ys = Float64[]
+
+    # build up coords:  # (alternative: use @series)
+    for xx in v
+        (x, y) = xx
+
+        # use NaNs to separate
+        append!(xs, [x.lo, x.hi, x.hi, x.lo, NaN])
+        append!(ys, [y.lo, y.lo, y.hi, y.hi, NaN])
+
+    end
+
+    alpha --> 0.5
+
+    #x = xs
+    #y = ys
+
+    #x, y
+
+    xs, ys
+
+end

--- a/test/root_finding_tests/wilkinson.jl
+++ b/test/root_finding_tests/wilkinson.jl
@@ -45,9 +45,8 @@ end
 
 # Generate Wilkinson functions W₃ etc.:
 for n in 1:15
-    fn_name = symbol(string("W", subscriptify(n)))
+    fn_name = Symbol("W", subscriptify(n))
     expr = generate_wilkinson_horner(n)
 
     @eval $(fn_name)(x) = $(expr)
 end
-


### PR DESCRIPTION
Adds a plot recipe for (only) 2D `IntervalBox`es using `RecipesBase.jl`.

This enables plotting using `Plots.jl` via `plot(X)` or `plot([X, Y])`,
i.e. individual `IntervalBox`es or of a `Vector` of `IntervalBox`es.