### PR TITLE
WIP: Mechanism for changing global rounding mode

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,5 @@
 julia 0.4
-CRlibm 0.4
+CRlibm 0.3.1 0.4
 Compat 0.7.11
 FixedSizeArrays 0.1.2
 ForwardDiff 0.2.0

--- a/src/ValidatedNumerics.jl
+++ b/src/ValidatedNumerics.jl
@@ -80,7 +80,8 @@ function __init__()
     setprecision(Interval, 256)  # set up pi
     setprecision(Interval, Float64)
 
-    CRlibm.setup()
+    # CRlibm.setup()
+    setup_rounded_functions(:none)
 end
 
 

--- a/src/ValidatedNumerics.jl
+++ b/src/ValidatedNumerics.jl
@@ -102,8 +102,6 @@ function __init__()
 
     # CRlibm.setup()
 
-    rounding_mode = get_rounding_mode()
-    setup_rounded_functions(rounding_mode)
 end
 
 

--- a/src/ValidatedNumerics.jl
+++ b/src/ValidatedNumerics.jl
@@ -71,6 +71,26 @@ export
     com, dac, def, trv, ill
 
 
+function get_rounding_mode()
+    if !haskey(ENV, "VN_ROUNDING")
+        return :correct
+    else
+        mode_string = ENV["VN_ROUNDING"]
+
+        if mode_string == "CORRECT"
+            return :correct
+
+        elseif mode_string == "FAST"
+            return :fast
+
+        elseif mode_string == "NONE"
+            return :none
+
+        else
+            warn("Rounding mode $mode_string node defined. Falling back to `:correct`")
+        end
+    end
+end
 
 
 function __init__()
@@ -81,7 +101,9 @@ function __init__()
     setprecision(Interval, Float64)
 
     # CRlibm.setup()
-    setup_rounded_functions(:none)
+
+    rounding_mode = get_rounding_mode()
+    setup_rounded_functions(rounding_mode)
 end
 
 

--- a/src/intervals/rounding.jl
+++ b/src/intervals/rounding.jl
@@ -2,75 +2,168 @@
 # E.g.  +(a, b, RoundDown)
 # Some, like sin(a, RoundDown)  are already defined in CRlibm
 
+# Rounding modes:
+# - :correct  # correct rounding
+# - :fast     # fast rounding by prevfloat and nextfloat  (slightly wider than needed)
+# - :none     # no rounding at all for speed
 
-# import Base: +, -, *, /, sin, sqrt, inv, ^, zero, convert, parse
-
-
-# unary minus:
--{T<:AbstractFloat}(a::T, ::RoundingMode) = -a  # ignore rounding
-
-# zero:
-zero{T<:AbstractFloat}(a::Interval{T}, ::RoundingMode) = zero(T)
-zero{T<:AbstractFloat}(::Type{T}, ::RoundingMode) = zero(T)
-
-convert(::Type{BigFloat}, x, rounding_mode::RoundingMode) = setrounding(BigFloat, rounding_mode) do
-    convert(BigFloat, x)
-end
-
-parse{T}(::Type{T}, x, rounding_mode::RoundingMode) = setrounding(T, rounding_mode) do
-    parse(T, x)
-end
-
-
-# no-ops for rational rounding:
-for f in (:+, :-, :*, :/)
-    @eval $f{T<:Rational}(a::T, b::T, ::RoundingMode) = $f(a, b)
-end
-
-sqrt{T<:Rational}(a::T, rounding_mode::RoundingMode) = setrounding(float(T), rounding_mode) do
-    sqrt(float(a))
-end
-
-
-
-for mode in (:Down, :Up)
-
-    mode1 = Expr(:quote, mode)
-    mode1 = :(::RoundingMode{$mode1})
-
-    mode2 = Symbol("Round", mode)
-
-
-    for f in (:+, :-, :*, :/,
-                :atan2)
-
-        @eval begin
-            function $f{T<:AbstractFloat}(a::T, b::T, $mode1)
-                setrounding(T, $mode2) do
-                    $f(a, b)
-                end
-            end
-        end
+function setup_rounded_functions(ROUNDING)
+    
+    if ROUNDING ∉ (:correct, :fast, :none)
+        throw(ArgumentError("ROUNDING must be one of `:correct`, `:fast`, `:none`"))
     end
 
     @eval begin
-        function ^{T<:AbstractFloat,S}(a::T, b::S, $mode1)
-            setrounding(T, $mode2) do
-                ^(a, b)
-            end
+        # unary minus:
+        -{T<:AbstractFloat}(a::T, ::RoundingMode) = -a  # ignore rounding
+
+        # zero:
+        zero{T<:AbstractFloat}(a::Interval{T}, ::RoundingMode) = zero(T)
+        zero{T<:AbstractFloat}(::Type{T}, ::RoundingMode) = zero(T)
+
+        convert(::Type{BigFloat}, x, rounding_mode::RoundingMode) = setrounding(BigFloat, rounding_mode) do
+            convert(BigFloat, x)
         end
+
+        parse{T}(::Type{T}, x, rounding_mode::RoundingMode) = setrounding(T, rounding_mode) do
+            parse(T, x)
+        end
+
+
+        sqrt{T<:Rational}(a::T, rounding_mode::RoundingMode) = setrounding(float(T), rounding_mode) do
+            sqrt(float(a))
+        end
+
+    end
+
+    # no-ops for rational rounding:
+    for f in (:+, :-, :*, :/)
+        @eval $f{T<:Rational}(a::T, b::T, ::RoundingMode) = $f(a, b)
     end
 
 
-    for f in (:sqrt, :inv,
-            :tanh, :asinh, :acosh, :atanh)   # these functions not in CRlibm
-        @eval begin
-            function $f{T<:AbstractFloat}(a::T, $mode1)
-                setrounding(T, $mode2) do
-                    $f(a)
+
+    for mode in (:Down, :Up) #, T in (:Float64)
+
+        mode1 = Expr(:quote, mode)
+        mode1 = :(::RoundingMode{$mode1})
+
+        mode2 = Symbol("Round", mode)
+
+
+        # arithmetic:
+        for f in (:+, :-, :*, :/, :atan2)
+
+            if ROUNDING == :correct
+                @eval function $f{T<:AbstractFloat}(a::T, b::T, $mode1)
+                        setrounding(T, $mode2) do
+                            $f(a, b)
+                        end
+                      end
+
+            elseif ROUNDING == :fast
+                @eval begin
+                    function $f{T<:AbstractFloat}(a::T, b::T, ::RoundingMode{:Down})
+                        prevfloat($f(a, b))
+                    end
+
+                    function $f{T<:AbstractFloat}(a::T, b::T, ::RoundingMode{:Up})
+                        nextfloat($f(a, b))
+                    end
+                end
+
+            elseif ROUNDING == :none
+                @eval $f{T<:AbstractFloat}(a::T, b::T, $mode1) = $f(a, b)  # no rounding
+
+            end
+        end
+
+
+        # power:
+        if ROUNDING == :correct
+
+            @eval function ^{T<:AbstractFloat,S}(a::T, b::S, $mode1)
+                      setrounding(T, $mode2) do
+                          ^(a, b)
+                      end
+                  end
+
+        elseif ROUNDING == :fast
+
+            @eval begin
+                function $f{T<:AbstractFloat}(a::T, b::T, ::RoundingMode{:Down})
+                    prevfloat(a^b)
+                end
+
+                function $f{T<:AbstractFloat}(a::T, b::T, ::RoundingMode{:Up})
+                    nextfloat(a^b)
                 end
             end
+
+        elseif ROUNDING == :none
+
+            @eval ^{T<:AbstractFloat}(a::T, b::T, $mode1) = a^b
+
+        end
+
+
+        # non-CRlibm
+        for f in (:sqrt, :inv,
+                :tanh, :asinh, :acosh, :atanh)   # these functions not in CRlibm
+
+            if ROUNDING == :correct
+                @eval function $f{T<:AbstractFloat}(a::T, $mode1)
+                          setrounding(T, $mode2) do
+                              $f(a)
+                          end
+                      end
+
+            elseif ROUNDING == :fast
+                @eval begin
+                          function $f{T<:AbstractFloat}(a::T, ::RoundingMode{:Down})
+                              prevfloat($f(a))
+                          end
+
+                          function $f{T<:AbstractFloat}(a::T, ::RoundingMode{:Up})
+                              nextfloat($f(a))
+                          end
+                      end
+
+            elseif ROUNDING == :none
+
+                @eval $f{T<:AbstractFloat}(a::T, ::RoundingMode) = $f(a)
+
+            end
+
         end
     end
 
+    # Functions defined in CRlibm
+    if ROUNDING == :correct
+        CRlibm.setup()
+
+    else
+
+        for f in CRlibm.functions
+
+            if ROUNDING == :fast
+
+                @eval begin
+                    function $f{T<:AbstractFloat}(a::T, ::RoundingMode{:Down})
+                        prevfloat($f(a))
+                    end
+
+                    function $f{T<:AbstractFloat}(a::T, ::RoundingMode{:Up})
+                        nextfloat($f(a))
+                    end
+                end
+
+            elseif ROUNDING == :none
+
+                @eval $f{T<:AbstractFloat}(a::T, ::RoundingMode) = $f(a)
+
+            end
+        end
+
+    end
 end

--- a/src/intervals/rounding.jl
+++ b/src/intervals/rounding.jl
@@ -92,18 +92,18 @@ function setup_rounded_functions(ROUNDING)
         elseif ROUNDING == :fast
 
             @eval begin
-                function ^{T<:AbstractFloat}(a::T, b::T, ::RoundingMode{:Down})
+                function ^{T<:AbstractFloat,S}(a::T, b::S, ::RoundingMode{:Down})
                     prevfloat(a^b)
                 end
 
-                function ^{T<:AbstractFloat}(a::T, b::T, ::RoundingMode{:Up})
+                function ^{T<:AbstractFloat,S}(a::T, b::S, ::RoundingMode{:Up})
                     nextfloat(a^b)
                 end
             end
 
         elseif ROUNDING == :none
 
-            @eval ^{T<:AbstractFloat}(a::T, b::T, $mode1) = a^b
+            @eval ^{T<:AbstractFloat,S}(a::T, b::S, $mode1) = a^b
 
         end
 

--- a/src/intervals/rounding.jl
+++ b/src/intervals/rounding.jl
@@ -7,8 +7,9 @@
 # - :fast     # fast rounding by prevfloat and nextfloat  (slightly wider than needed)
 # - :none     # no rounding at all for speed
 
+
 function setup_rounded_functions(ROUNDING)
-    
+
     if ROUNDING ∉ (:correct, :fast, :none)
         throw(ArgumentError("ROUNDING must be one of `:correct`, `:fast`, `:none`"))
     end
@@ -91,11 +92,11 @@ function setup_rounded_functions(ROUNDING)
         elseif ROUNDING == :fast
 
             @eval begin
-                function $f{T<:AbstractFloat}(a::T, b::T, ::RoundingMode{:Down})
+                function ^{T<:AbstractFloat}(a::T, b::T, ::RoundingMode{:Down})
                     prevfloat(a^b)
                 end
 
-                function $f{T<:AbstractFloat}(a::T, b::T, ::RoundingMode{:Up})
+                function ^{T<:AbstractFloat}(a::T, b::T, ::RoundingMode{:Up})
                     nextfloat(a^b)
                 end
             end

--- a/src/intervals/rounding.jl
+++ b/src/intervals/rounding.jl
@@ -158,7 +158,7 @@ end
 # Functions defined in CRlibm
 
 @static if ROUNDING == :correct
-    CRlibm.setup()
+    # CRlibm.setup()
 
 else
 


### PR DESCRIPTION
To use run Julia as follows from the command line:

```
> VN_ROUNDING=fast julia --compilecache=no
```
The options are `fast`, `none` and `correct`.
The default is `correct`.

The `--compilecache=no` is required each time the mode is changed.
Currently the `VN_ROUNDING=...` is required even if the mode is unchanged.

Sample timings for the following benchmark function after warmup:
```julia
function bench(N)
    a = 0.1 .. 0.1
    sum(sqrt(n*a) for n in 1:N)
end

julia> bench(10^7)
```

- correct: 2.858399 seconds
- fast: 1.014718 seconds
- none:  0.878046 seconds

cc @lbenet
