### PR TITLE
Rewrite .. operator

### DIFF
--- a/src/intervals/conversion.jl
+++ b/src/intervals/conversion.jl
@@ -95,8 +95,11 @@ convert{T<:Integer, S<:BigFloat}(::Type{Interval{Rational{T}}}, x::S) =
     Interval(rationalize(T, x))
 
 
+# conversion to Interval without explicit type:
 function convert(::Type{Interval}, x::Real)
     T = typeof(float(x))
 
     return convert(Interval{T}, x)
 end
+
+convert(::Type{Interval}, x::Interval) = x

--- a/src/intervals/conversion.jl
+++ b/src/intervals/conversion.jl
@@ -93,3 +93,10 @@ convert{T<:Integer, S<:Float64}(::Type{Interval{Rational{T}}}, x::S) =
 
 convert{T<:Integer, S<:BigFloat}(::Type{Interval{Rational{T}}}, x::S) =
     Interval(rationalize(T, x))
+
+
+function convert(::Type{Interval}, x::Real)
+    T = typeof(float(x))
+
+    return convert(Interval{T}, x)
+end

--- a/src/intervals/intervals.jl
+++ b/src/intervals/intervals.jl
@@ -57,7 +57,7 @@ include("hyperbolic.jl")
 
 # Syntax for intervals
 
-a..b = @interval(a, b)
+a..b = Interval(convert(Interval, a).lo, convert(Interval, b).hi)
 
 macro I_str(ex)  # I"[3,4]"
     @interval(ex)

--- a/test/interval_tests/construction.jl
+++ b/test/interval_tests/construction.jl
@@ -220,7 +220,7 @@ end
 
 end
 
-@testet "Conversions between different types of interval" begin
+@testset "Conversions between different types of interval" begin
     a = convert(Interval{BigFloat}, 3..4)
     @test typeof(a) == Interval{BigFloat}
 

--- a/test/interval_tests/construction.jl
+++ b/test/interval_tests/construction.jl
@@ -189,10 +189,27 @@ end
     # @test imag(b) == Interval(-15.200784463067956, -15.20078446306795)
 end
 
+@testset ".. tests" begin
+
+    # part of issue #172:
+    a = big(0.0)..1
+    @test typeof(a) == Interval{BigFloat}
+end
+
 @testset "± tests" begin
     setprecision(Interval, Float64)
 
     @test 3 ± 0.5 == Interval(2.5, 3.5)
     @test 3 ± 0.1 == Interval(2.9, 3.1)
     @test 0.5 ± 1 == Interval(-0.5, 1.5)
+
+    # issue 172:
+    a = @interval(1) ± 1
+    @test a == Interval(-0.0, 2.0)
+    @test typeof(a) == Interval{Float64}
+
+    a =  @biginterval(1) ± 1
+    @test a == Interval(big(-0.0), big(2.0))
+    @test typeof(a) == Interval{BigFloat}
+
 end

--- a/test/interval_tests/construction.jl
+++ b/test/interval_tests/construction.jl
@@ -191,8 +191,14 @@ end
 
 @testset ".. tests" begin
 
+
+    a = 0.1..0.3
+    @test big"0.1" ∈ a
+    @test big"0.3" ∈ a
+
     # part of issue #172:
-    a = big(0.0)..1
+
+    a = big(0.1)..2
     @test typeof(a) == Interval{BigFloat}
 end
 

--- a/test/interval_tests/construction.jl
+++ b/test/interval_tests/construction.jl
@@ -219,3 +219,21 @@ end
     @test typeof(a) == Interval{BigFloat}
 
 end
+
+@testet "Conversions between different types of interval" begin
+    a = convert(Interval{BigFloat}, 3..4)
+    @test typeof(a) == Interval{BigFloat}
+
+    a = convert(Interval{Float64}, @biginterval(3, 4))
+    @test typeof(a) == Interval{Float64}
+end
+
+@testset "Conversion to Interval" begin
+    a = convert(Interval, 3)
+    @test a == Interval(3.0)
+    @test typeof(a) == Interval{Float64}
+
+    a = convert(Interval, big(3))
+    @test typeof(a) == Interval{BigFloat}
+
+end


### PR DESCRIPTION
Rewrites `a..b` to not use `@interval`.
Does this by using `convert(Interval, a)` and `convert(Interval, b)`.