### PR TITLE
Rewrite display.jl

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -33,7 +33,7 @@ or
 
 
 ## v0.4.3
-- Fix display of intervals with different displaymode options; [#146](https://github.com/dpsanders/ValidatedNumerics.jl/pull/146)
+- Fix display of intervals with different setdisplay options; [#146](https://github.com/dpsanders/ValidatedNumerics.jl/pull/146)
 
 - Add emptyinterval(x::IntervalBox); [#145](https://github.com/dpsanders/ValidatedNumerics.jl/pull/145)
 
@@ -48,7 +48,7 @@ or
 # v0.4
 - Added decorated intervals [#112](https://github.com/dpsanders/ValidatedNumerics.jl/pull/112)
 
-- Added `displaymode` function for modifying how intervals are displayed [#115](https://github.com/dpsanders/ValidatedNumerics.jl/pull/115)
+- Added `setdisplay` function for modifying how intervals are displayed [#115](https://github.com/dpsanders/ValidatedNumerics.jl/pull/115)
 
 - Added `±` syntax for creating intervals as e.g. `1.3 ± 0.1` [#116](https://github.com/dpsanders/ValidatedNumerics.jl/pull/116)
 

--- a/docs/decorations.md
+++ b/docs/decorations.md
@@ -52,7 +52,7 @@ julia> X = DecoratedInterval(3, 4)
 
 By default, decorations are not displayed. The following turns on display of decorations:
 ```
-julia> displaymode(decorations=true)
+julia> setdisplay(decorations=true)
 
 julia> X
 [3, 4]_com

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -383,23 +383,23 @@ julia> displaymode(sigfigs=10)
 julia> a
 [1.099999999, 3.141592654]
 
-julia> displaymode(format=:full)
+julia> displaymode(:full)
 
 julia> a
 Interval(1.0999999999999999, 3.1415926535897936)
 
-julia> displaymode(format=:midpoint)
+julia> displaymode(:midpoint)
 
 julia> a
 2.120796327 ± 1.020796327
 
-julia> displaymode(format=:midpoint, sigfigs=4)
+julia> displaymode(:midpoint, sigfigs=4)
 4
 
 julia> a
 2.121 ± 1.021
 
-julia> displaymode(format=:standard)
+julia> displaymode(:standard)
 
 julia> a
 [1.099, 3.142]

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -357,8 +357,8 @@ rounding(Interval)
 ```
 
 ## Display modes
-There are several useful output representations for intervals, some of which we have already touched on. The display is controlled globally by the `displaymode` function, which has
-the following options, specified by keyword arguments (type `?displaymode` to get help at the REPL):
+There are several useful output representations for intervals, some of which we have already touched on. The display is controlled globally by the `setdisplay` function, which has
+the following options, specified by keyword arguments (type `?setdisplay` to get help at the REPL):
 
 - `format`: interval output format
 
@@ -377,29 +377,29 @@ the following options, specified by keyword arguments (type `?displaymode` to ge
 julia> a = @interval(1.1, pi)
 [1.09999, 3.1416]
 
-julia> displaymode(sigfigs=10)
+julia> setdisplay(sigfigs=10)
 10
 
 julia> a
 [1.099999999, 3.141592654]
 
-julia> displaymode(:full)
+julia> setdisplay(:full)
 
 julia> a
 Interval(1.0999999999999999, 3.1415926535897936)
 
-julia> displaymode(:midpoint)
+julia> setdisplay(:midpoint)
 
 julia> a
 2.120796327 ± 1.020796327
 
-julia> displaymode(:midpoint, sigfigs=4)
+julia> setdisplay(:midpoint, sigfigs=4)
 4
 
 julia> a
 2.121 ± 1.021
 
-julia> displaymode(:standard)
+julia> setdisplay(:standard)
 
 julia> a
 [1.099, 3.142]

--- a/src/ValidatedNumerics.jl
+++ b/src/ValidatedNumerics.jl
@@ -37,7 +37,7 @@ export
     precedes, strictprecedes, ≺,
     entireinterval, isentire, nai, isnai, isthin, iscommon,
     widen, infimum, supremum,
-    parameters, eps, dist, 
+    parameters, eps, dist,
     pi_interval,
     midpoint_radius, interval_from_midpoint_radius,
     RoundTiesToEven, RoundTiesToAway,
@@ -45,7 +45,7 @@ export
     .., @I_str, ±
 
 export
-    displaymode
+    setdisplay
 
 export
     setindex

--- a/src/display.jl
+++ b/src/display.jl
@@ -6,7 +6,6 @@ end
 
 const display_params = DisplayParameters(:standard, false, 6)
 
-const display_options = [:standard, :full, :midpoint]
 
 doc"""
     setdisplay(;kw)
@@ -20,7 +19,7 @@ The following options are available:
     - `:full`: `Interval(1, 2)`
     - `:midpoint`: 1.5 ± 0.5
 
-- `sigfigs`: number of significant figures to show in `standard` mode
+- `sigfigs`: number of significant figures to show in `standard` mode; the default is 6
 
 - `decorations` (boolean):  show decorations or not
 
@@ -29,30 +28,25 @@ Example:
 julia> setdisplay(:full, decorations=true)
 ```
 """
-function setdisplay(format=nothing; decorations=nothing, sigfigs::Integer=-1)
-    if format != nothing
+function setdisplay(format = display_params.format;
+                    decorations = display_params.decorations, sigfigs::Integer = display_params.sigfigs)
 
-        if format in display_options
-            display_params.format = format
-        else
-            throw(ArgumentError("Allowed format option is one of  $display_options."))
-        end
-
+    if format ∉ (:standard, :full, :midpoint)
+        throw(ArgumentError("Allowed format option is one of  $display_options."))
     end
 
-    if decorations != nothing
-
-        if decorations ∈ (true, false)
-            display_params.decorations = decorations
-
-        else
-            throw(ArgumentError("`decorations` must be `true` or `false`"))
-        end
+    if decorations ∉ (true, false)
+        throw(ArgumentError("`decorations` must be `true` or `false`"))
     end
 
-    if sigfigs >= 0
-        display_params.sigfigs = sigfigs
+    if sigfigs < 1
+        throw(ArgumentError("`sigfigs` must be `>= 1`"))
     end
+
+    # update values in display_params:
+    display_params.format = format
+    display_params.decorations = decorations
+    display_params.sigfigs = sigfigs
 end
 
 

--- a/src/display.jl
+++ b/src/display.jl
@@ -9,9 +9,9 @@ const display_params = DisplayParameters(:standard, false, 6)
 const display_options = [:standard, :full, :midpoint]
 
 doc"""
-    displaymode(;kw)
+    setdisplay(;kw)
 
-`displaymode` changes how intervals are displayed using keyword arguments.
+`setdisplay` changes how intervals are displayed using keyword arguments.
 The following options are available:
 
 - `format`: interval output format
@@ -26,10 +26,10 @@ The following options are available:
 
 Example:
 ```
-julia> displaymode(:full, decorations=true)
+julia> setdisplay(:full, decorations=true)
 ```
 """
-function displaymode(format=nothing; decorations=nothing, sigfigs::Integer=-1)
+function setdisplay(format=nothing; decorations=nothing, sigfigs::Integer=-1)
     if format != nothing
 
         if format in display_options
@@ -157,11 +157,11 @@ function representation(a::Interval{BigFloat}, format=nothing)
 
     if format == :standard
 
-        string(basic_representation(a, format), subscriptify(precision(a.lo)))
+        return string(basic_representation(a, format), subscriptify(precision(a.lo)))
 
     else
 
-        basic_representation(a, format)
+        return basic_representation(a, format)
 
     end
 end

--- a/src/display.jl
+++ b/src/display.jl
@@ -146,7 +146,8 @@ function subscriptify(n::Int)
 end
 
 
-representation(a::Interval, format=nothing) = basic_representation(a, format)
+# fall-back:
+representation{T}(a::Interval{T}, format=nothing) = basic_representation(a, format)
 
 function representation(a::Interval{BigFloat}, format=nothing)
 
@@ -167,7 +168,7 @@ function representation(a::Interval{BigFloat}, format=nothing)
 end
 
 
-function representation(a::DecoratedInterval, format=nothing)
+function representation{T}(a::DecoratedInterval{T}, format=nothing)
 
     if format == nothing
         format = display_params.format  # default
@@ -204,7 +205,11 @@ function representation(X::IntervalBox, format=nothing)
 end
 
 
-for T in (Interval, DecoratedInterval, IntervalBox)
-    @eval show(io::IO, a::$T) = print(io, representation(a))
-    @eval showall(io::IO, a::$T) = print(io, representation(a, :full))
+for T in (Interval, DecoratedInterval)
+    @eval show{S}(io::IO, a::$T{S}) = print(io, representation(a))
+    @eval showall{S}(io::IO, a::$T{S}) = print(io, representation(a, :full))
 end
+
+T = IntervalBox
+@eval show(io::IO, a::$T) = print(io, representation(a))
+@eval showall(io::IO, a::$T) = print(io, representation(a, :full))

--- a/src/display.jl
+++ b/src/display.jl
@@ -175,10 +175,10 @@ function representation{T}(a::DecoratedInterval{T}, format=nothing)
     end
 
     if format==:full
-        return "DecoratedInterval($(basic_representation(interval_part(a), format)), $(decoration(a)))"
+        return "DecoratedInterval($(representation(interval_part(a), format)), $(decoration(a)))"
     end
 
-    interval = basic_representation(interval_part(a), format)
+    interval = representation(interval_part(a), format)
 
     if display_params.decorations
         string(interval, "_", decoration(a))

--- a/test/display_tests/display.jl
+++ b/test/display_tests/display.jl
@@ -81,7 +81,7 @@ setprecision(Interval, Float64)
 
 
     setprecision(Interval, 256)
-    
+
     @testset "DecoratedInterval" begin
         a = @decorated(1, 2)
         @test typeof(a)== DecoratedInterval{Float64}
@@ -160,6 +160,29 @@ setprecision(Interval, Float64)
         @test string(X) == "IntervalBox(Interval(-Inf, Inf), Interval(-Inf, Inf))"
 
     end
+end
 
+@testset "showall" begin
+    setdisplay(:standard, decorations=false, sigfigs=6)
+    setprecision(128)
+
+    x = 0..1
+    @test string(x) == [0, 1]
+    @test sprint(showall, x) == "Interval(0.0, 1.0)"
+
+    x = @biginterval(0, 1)
+    @test string(x) == "[0, 1]₁₂₈"
+    @test sprint(showall, x) == "Interval(0.000000000000000000000000000000000000000, 1.000000000000000000000000000000000000000)"
+
+    x = DecoratedInterval(0, 1, dac)
+    @test string(x) == "[0, 1]"
+    @test sprint(showall, x) == "DecoratedInterval(Interval(0.0, 1.0), dac)"
+
+    x = DecoratedInterval(big(0), big(1), def)
+    @test string(x) == [0, 1]₁₂₈
+    @test sprint(showall, x) == "DecoratedInterval(Interval(0.000000000000000000000000000000000000000, 1.000000000000000000000000000000000000000), def)"
+
+    setdisplay(decorations=true)
+    @test string(x) == "[0, 1]₁₂₈_def"
 
 end

--- a/test/display_tests/display.jl
+++ b/test/display_tests/display.jl
@@ -167,7 +167,7 @@ end
     setprecision(128)
 
     x = 0..1
-    @test string(x) == [0, 1]
+    @test string(x) == "[0, 1]"
     @test sprint(showall, x) == "Interval(0.0, 1.0)"
 
     x = @biginterval(0, 1)

--- a/test/display_tests/display.jl
+++ b/test/display_tests/display.jl
@@ -60,6 +60,9 @@ setprecision(Interval, Float64)
             @test string(b) == "0.1 ± 1.20001"
             @test string(c) == "3.14159 ± 0"
             @test string(d) == "3.14159 ± 4.4409e-16"
+
+            # issue 175:
+            @test string(@biginterval(1, 2)) == "1.5 ± 0.5"
         end
     end
 
@@ -81,12 +84,29 @@ setprecision(Interval, Float64)
         @test typeof(a)== DecoratedInterval{Float64}
 
         setdisplay(:standard, decorations=false)
-
         @test string(a) == "[1, 2]"
 
         setdisplay(:standard, decorations=true)
-
         @test string(a) == "[1, 2]_com"
+
+        # issue 131:
+        a = DecoratedInterval(big(2), big(3), com)
+
+        setdisplay(:standard, decorations=false)
+        @test string(a) == "[2, 3]₂₅₆"
+
+        setdisplay(decorations=true)
+        @test string(a) == "[2, 3]₂₅₆_com"
+
+        setdisplay(:full)
+        @test string(a) == "DecoratedInterval(Interval(2.000000000000000000000000000000000000000000000000000000000000000000000000000000, 3.000000000000000000000000000000000000000000000000000000000000000000000000000000), com)"
+
+        setdisplay(:midpoint)
+        @test string(a) == "2.5 ± 0.5_com"
+
+        setdisplay(decorations=false)
+        @test string(a) == "2.5 ± 0.5"
+
     end
 
 
@@ -137,4 +157,6 @@ setprecision(Interval, Float64)
         @test string(X) == "IntervalBox(Interval(-Inf, Inf), Interval(-Inf, Inf))"
 
     end
+
+
 end

--- a/test/display_tests/display.jl
+++ b/test/display_tests/display.jl
@@ -18,7 +18,7 @@ setprecision(Interval, Float64)
         d = @interval(π)
 
         @testset "6 sig figs" begin
-            displaymode(format=:standard, sigfigs=6)
+            displaymode(:standard, sigfigs=6)
 
             @test string(a) == "[1, 2]"
             @test string(b) == "[-1.10001, 1.30001]"
@@ -45,7 +45,7 @@ setprecision(Interval, Float64)
         end
 
         @testset "Full" begin
-            displaymode(format=:full)
+            displaymode(:full)
 
             @test string(a) == "Interval(1.0, 2.0)"
             @test string(b) == "Interval(-1.1, 1.3)"
@@ -54,7 +54,7 @@ setprecision(Interval, Float64)
         end
 
         @testset "Midpoint" begin
-            displaymode(format=:midpoint, sigfigs=6)
+            displaymode(:midpoint, sigfigs=6)
 
             @test string(a) == "1.5 ± 0.5"
             @test string(b) == "0.1 ± 1.20001"
@@ -66,13 +66,13 @@ setprecision(Interval, Float64)
     @testset "Interval{Rational{T}}" begin
         a = Interval(1//3, 5//4)
         @test typeof(a)== Interval{Rational{Int}}
-        displaymode(format=:standard)
+        displaymode(:standard)
         @test string(a) == "[1//3, 5//4]"
 
-        displaymode(format=:full)
+        displaymode(:full)
         @test string(a) == "Interval(1//3, 5//4)"
 
-        displaymode(format=:midpoint)
+        displaymode(:midpoint)
         @test string(a) == "19//24 ± 11//24"
     end
 
@@ -80,11 +80,11 @@ setprecision(Interval, Float64)
         a = @decorated(1, 2)
         @test typeof(a)== DecoratedInterval{Float64}
 
-        displaymode(format=:standard, decorations=false)
+        displaymode(:standard, decorations=false)
 
         @test string(a) == "[1, 2]"
 
-        displaymode(format=:standard, decorations=true)
+        displaymode(:standard, decorations=true)
 
         @test string(a) == "[1, 2]_com"
     end
@@ -93,26 +93,26 @@ setprecision(Interval, Float64)
     setprecision(Interval, 128)
 
     @testset "BigFloat intervals" begin
-        displaymode(format=:standard, decorations=false)
+        displaymode(:standard, decorations=false)
 
         a = @interval big(1)
         @test typeof(a)== Interval{BigFloat}
         @test string(a) == "[1, 1]₁₂₈"
 
-        displaymode(format=:full)
+        displaymode(:full)
         @test string(a) == "Interval(1.000000000000000000000000000000000000000, 1.000000000000000000000000000000000000000)"
 
 
         a = DecoratedInterval(big(2), big(3), com)
         @test typeof(a)== DecoratedInterval{BigFloat}
 
-        displaymode(format=:standard, decorations=false)
+        displaymode(:standard, decorations=false)
         @test string(a) == "[2, 3]₁₂₈"
 
-        displaymode(format=:standard, decorations=true)
+        displaymode(:standard, decorations=true)
         @test string(a) == "[2, 3]₁₂₈_com"
 
-        displaymode(format=:full)
+        displaymode(:full)
         @test string(a) == "DecoratedInterval(Interval(2.000000000000000000000000000000000000000, 3.000000000000000000000000000000000000000), com)"
     end
 
@@ -121,7 +121,7 @@ setprecision(Interval, Float64)
 
     @testset "IntervalBox" begin
 
-        displaymode(format=:standard, sigfigs=6)
+        displaymode(:standard, sigfigs=6)
 
         X = IntervalBox(1..2, 3..4)
         @test typeof(X) == IntervalBox{2,Float64}
@@ -133,7 +133,7 @@ setprecision(Interval, Float64)
         X = IntervalBox(-Inf..Inf, -Inf..Inf)
         @test string(X) == "[-∞, ∞] × [-∞, ∞]"
 
-        displaymode(format=:full)
+        displaymode(:full)
         @test string(X) == "IntervalBox(Interval(-Inf, Inf), Interval(-Inf, Inf))"
 
     end

--- a/test/display_tests/display.jl
+++ b/test/display_tests/display.jl
@@ -8,7 +8,7 @@ using ValidatedNumerics
 
 setprecision(Interval, Float64)
 
-@testset "displaymode tests" begin
+@testset "setdisplay tests" begin
 
     @testset "Interval" begin
 
@@ -18,7 +18,7 @@ setprecision(Interval, Float64)
         d = @interval(π)
 
         @testset "6 sig figs" begin
-            displaymode(:standard, sigfigs=6)
+            setdisplay(:standard, sigfigs=6)
 
             @test string(a) == "[1, 2]"
             @test string(b) == "[-1.10001, 1.30001]"
@@ -27,7 +27,7 @@ setprecision(Interval, Float64)
         end
 
         @testset "10 sig figs" begin
-            displaymode(sigfigs=10)
+            setdisplay(sigfigs=10)
 
             @test string(a) == "[1, 2]"
             @test string(b) == "[-1.100000001, 1.300000001]"
@@ -36,7 +36,7 @@ setprecision(Interval, Float64)
         end
 
         @testset "20 sig figs" begin
-            displaymode(sigfigs=20)
+            setdisplay(sigfigs=20)
 
             @test string(a) == "[1, 2]"
             @test string(b) == "[-1.1000000000000000889, 1.3000000000000000445]"
@@ -45,7 +45,7 @@ setprecision(Interval, Float64)
         end
 
         @testset "Full" begin
-            displaymode(:full)
+            setdisplay(:full)
 
             @test string(a) == "Interval(1.0, 2.0)"
             @test string(b) == "Interval(-1.1, 1.3)"
@@ -54,7 +54,7 @@ setprecision(Interval, Float64)
         end
 
         @testset "Midpoint" begin
-            displaymode(:midpoint, sigfigs=6)
+            setdisplay(:midpoint, sigfigs=6)
 
             @test string(a) == "1.5 ± 0.5"
             @test string(b) == "0.1 ± 1.20001"
@@ -66,13 +66,13 @@ setprecision(Interval, Float64)
     @testset "Interval{Rational{T}}" begin
         a = Interval(1//3, 5//4)
         @test typeof(a)== Interval{Rational{Int}}
-        displaymode(:standard)
+        setdisplay(:standard)
         @test string(a) == "[1//3, 5//4]"
 
-        displaymode(:full)
+        setdisplay(:full)
         @test string(a) == "Interval(1//3, 5//4)"
 
-        displaymode(:midpoint)
+        setdisplay(:midpoint)
         @test string(a) == "19//24 ± 11//24"
     end
 
@@ -80,11 +80,11 @@ setprecision(Interval, Float64)
         a = @decorated(1, 2)
         @test typeof(a)== DecoratedInterval{Float64}
 
-        displaymode(:standard, decorations=false)
+        setdisplay(:standard, decorations=false)
 
         @test string(a) == "[1, 2]"
 
-        displaymode(:standard, decorations=true)
+        setdisplay(:standard, decorations=true)
 
         @test string(a) == "[1, 2]_com"
     end
@@ -93,26 +93,26 @@ setprecision(Interval, Float64)
     setprecision(Interval, 128)
 
     @testset "BigFloat intervals" begin
-        displaymode(:standard, decorations=false)
+        setdisplay(:standard, decorations=false)
 
         a = @interval big(1)
         @test typeof(a)== Interval{BigFloat}
         @test string(a) == "[1, 1]₁₂₈"
 
-        displaymode(:full)
+        setdisplay(:full)
         @test string(a) == "Interval(1.000000000000000000000000000000000000000, 1.000000000000000000000000000000000000000)"
 
 
         a = DecoratedInterval(big(2), big(3), com)
         @test typeof(a)== DecoratedInterval{BigFloat}
 
-        displaymode(:standard, decorations=false)
+        setdisplay(:standard, decorations=false)
         @test string(a) == "[2, 3]₁₂₈"
 
-        displaymode(:standard, decorations=true)
+        setdisplay(:standard, decorations=true)
         @test string(a) == "[2, 3]₁₂₈_com"
 
-        displaymode(:full)
+        setdisplay(:full)
         @test string(a) == "DecoratedInterval(Interval(2.000000000000000000000000000000000000000, 3.000000000000000000000000000000000000000), com)"
     end
 
@@ -121,7 +121,7 @@ setprecision(Interval, Float64)
 
     @testset "IntervalBox" begin
 
-        displaymode(:standard, sigfigs=6)
+        setdisplay(:standard, sigfigs=6)
 
         X = IntervalBox(1..2, 3..4)
         @test typeof(X) == IntervalBox{2,Float64}
@@ -133,7 +133,7 @@ setprecision(Interval, Float64)
         X = IntervalBox(-Inf..Inf, -Inf..Inf)
         @test string(X) == "[-∞, ∞] × [-∞, ∞]"
 
-        displaymode(:full)
+        setdisplay(:full)
         @test string(X) == "IntervalBox(Interval(-Inf, Inf), Interval(-Inf, Inf))"
 
     end

--- a/test/display_tests/display.jl
+++ b/test/display_tests/display.jl
@@ -79,6 +79,9 @@ setprecision(Interval, Float64)
         @test string(a) == "19//24 ± 11//24"
     end
 
+
+    setprecision(Interval, 256)
+    
     @testset "DecoratedInterval" begin
         a = @decorated(1, 2)
         @test typeof(a)== DecoratedInterval{Float64}

--- a/test/display_tests/display.jl
+++ b/test/display_tests/display.jl
@@ -179,7 +179,7 @@ end
     @test sprint(showall, x) == "DecoratedInterval(Interval(0.0, 1.0), dac)"
 
     x = DecoratedInterval(big(0), big(1), def)
-    @test string(x) == [0, 1]₁₂₈
+    @test string(x) == "[0, 1]₁₂₈"
     @test sprint(showall, x) == "DecoratedInterval(Interval(0.000000000000000000000000000000000000000, 1.000000000000000000000000000000000000000), def)"
 
     setdisplay(decorations=true)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,7 +9,7 @@ using ValidatedNumerics
 
 # Interval tests:
 
-displaymode(format=:full)
+displaymode(:full)
 
 include("interval_tests/intervals.jl")
 include("multidim_tests/multidim.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,7 +9,7 @@ using ValidatedNumerics
 
 # Interval tests:
 
-displaymode(:full)
+setdisplay(:full)
 
 include("interval_tests/intervals.jl")
 include("multidim_tests/multidim.jl")


### PR DESCRIPTION
Fixes #202, #175, #131.

This changes the name of `displaymode` to `setdisplay`, and the syntax to the simpler

```
setdisplay(:full)
```
instead of the wordy
```
displaymode(format=:full)
```