### PR TITLE
Do not allow 2 NaNs in Interval

### DIFF
--- a/src/display.jl
+++ b/src/display.jl
@@ -65,7 +65,11 @@ function round_string(x::BigFloat, digits::Int, r::RoundingMode)
     (Ptr{UInt8}, Culong,  Ptr{UInt8}, Int32, Ptr{BigFloat}...),
     buf, lng + 1, "%.$(digits)R*g", Base.MPFR.to_mpfr(r), &x)
 
-    return unsafe_string(pointer(buf))
+    repr = unsafe_string(pointer(buf))
+
+    repr = replace(repr, "nan", "NaN")
+
+    return repr
 end
 
 round_string(x::Real, digits::Int, r::RoundingMode) = round_string(big(x), digits, r)

--- a/src/intervals/intervals.jl
+++ b/src/intervals/intervals.jl
@@ -13,11 +13,17 @@ immutable Interval{T<:Real} <: AbstractInterval
 
     function Interval(a::Real, b::Real)
 
+        if isnan(a) || isnan(b)
+            return new(NaN, NaN)  # nai
+        end
+
         if a > b
             (isinf(a) && isinf(b)) && return new(a, b)  # empty interval = [∞,-∞]
 
             throw(ArgumentError("Must have a ≤ b to construct Interval(a, b)."))
         end
+
+
 
         new(a, b)
     end

--- a/test/interval_tests/construction.jl
+++ b/test/interval_tests/construction.jl
@@ -248,6 +248,9 @@ end
 
 # issue 192:
 @testset "Disallow a single NaN in an interval" begin
-    @test Interval(NaN, 2) == Interval(NaN, NaN)
-    @test Interval(Inf, NaN) == Interval(NaN, NaN)
+    a = Interval(NaN, 2)
+    @test isnai(a)
+
+    a = Interval(Inf, NaN)
+    @test isnai(a)
 end

--- a/test/interval_tests/construction.jl
+++ b/test/interval_tests/construction.jl
@@ -249,8 +249,9 @@ end
 # issue 192:
 @testset "Disallow a single NaN in an interval" begin
     a = Interval(NaN, 2)
-    @test isnai(a)
+    @test isnan(a.lo) && isnan(a.hi)
 
     a = Interval(Inf, NaN)
-    @test isnai(a)
+    @test isnan(a.lo) && isnan(a.hi)
+
 end

--- a/test/interval_tests/construction.jl
+++ b/test/interval_tests/construction.jl
@@ -245,3 +245,9 @@ end
     @test Interval{BigFloat}(1) == @biginterval(1, 1)
     @test Interval{BigFloat}(big"1.1") == Interval(big"1.1", big"1.1")
 end
+
+# issue 192:
+@testset "Disallow a single NaN in an interval" begin
+    @test Interval(NaN, 2) == Interval(NaN, NaN)
+    @test Interval(Inf, NaN) == Interval(NaN, NaN)
+end


### PR DESCRIPTION
Fixes #192.

Note that this contains also the changes in `rewrite_display` and should be merged after that.