### PR TITLE
Improve interval strings

### DIFF
--- a/src/ValidatedNumerics.jl
+++ b/src/ValidatedNumerics.jl
@@ -92,6 +92,7 @@ include("intervals/intervals.jl")
 include("multidim/multidim.jl")
 include("decorations/decorations.jl")
 
+include("parsing.jl")
 include("display.jl")
 
 include("root_finding/root_finding.jl")

--- a/src/decorations/intervals.jl
+++ b/src/decorations/intervals.jl
@@ -18,6 +18,12 @@ The nomenclature of the follows the IEEE-1788 (2015) standard
 @enum DECORATION ill=0 trv=1 def=2 dac=3 com=4
 # Note that `isless`, and hence ``<` and `min`, are automatically defined for enums
 
+const decorations = Dict("ill" => ill,
+                         "trv" => trv,
+                         "def" => def,
+                         "dac" => dac,
+                         "com" => com)
+
 """
     DecoratedInterval
 
@@ -95,8 +101,11 @@ function convert{T<:Real}(::Type{DecoratedInterval{T}}, xx::DecoratedInterval)
     DecoratedInterval( x, decoration(xx) )
 end
 
+convert{T<:AbstractFloat}(::Type{DecoratedInterval{T}}, x::AbstractString) =
+    parse_decorated_string(T, x)
 
-# show(io::IO, x::DecoratedInterval) = print(io, x.interval, "_", x.decoration)
+big(x::DecoratedInterval) = DecoratedInterval(big(interval_part(x)),
+                                                decoration(x))
 
 macro decorated(ex...)
     local x

--- a/src/decorations/intervals.jl
+++ b/src/decorations/intervals.jl
@@ -102,7 +102,7 @@ function convert{T<:Real}(::Type{DecoratedInterval{T}}, xx::DecoratedInterval)
 end
 
 convert{T<:AbstractFloat}(::Type{DecoratedInterval{T}}, x::AbstractString) =
-    parse_decorated_string(T, x)
+    parse(DecoratedInterval{T}, x)
 
 big(x::DecoratedInterval) = DecoratedInterval(big(interval_part(x)),
                                                 decoration(x))

--- a/src/decorations/intervals.jl
+++ b/src/decorations/intervals.jl
@@ -18,11 +18,11 @@ The nomenclature of the follows the IEEE-1788 (2015) standard
 @enum DECORATION ill=0 trv=1 def=2 dac=3 com=4
 # Note that `isless`, and hence ``<` and `min`, are automatically defined for enums
 
-const decorations = Dict("ill" => ill,
-                         "trv" => trv,
-                         "def" => def,
-                         "dac" => dac,
-                         "com" => com)
+# const decorations = Dict("ill" => ill,
+#                          "trv" => trv,
+#                          "def" => def,
+#                          "dac" => dac,
+#                          "com" => com)
 
 """
     DecoratedInterval

--- a/src/intervals/conversion.jl
+++ b/src/intervals/conversion.jl
@@ -100,7 +100,8 @@ function convert{T<:AbstractFloat}(::Type{Interval{T}}, x::Float64)
     II = convert(Interval{T}, rationalize(x))
     # This prevents that rationalize(x) returns a zero when x is very small
     if x != zero(x) && II == zero(Interval{T})
-        II = Interval{T}(x)
+        return Interval(parse(T, string(x), RoundDown),
+                        parse(T, string(x), RoundUp))
     end
     II
 end

--- a/src/intervals/conversion.jl
+++ b/src/intervals/conversion.jl
@@ -18,77 +18,11 @@ promote_rule{T<:Real}(::Type{BigFloat}, ::Type{Interval{T}}) =
     Interval{promote_type(T, BigFloat)}
 
 
-function parse_decorated_string(T, s::AbstractString)
-    m = match(r"(\[.*\])(\_.*)?", s)
-
-    if m == nothing  # matched
-        throw(ArgumentError("Unable to process string $x as decorated interval"))
-
-    end
-
-    interval_string, decoration_string = m.captures
-    interval = parse_interval_string(T, interval_string)
-
-    # type unstable:
-    if decoration_string == nothing
-        decoration_string = "_com"
-    end
-
-    decoration_symbol = Symbol(decoration_string[2:end])
-    decoration = getfield(ValidatedNumerics, decoration_symbol)
-
-    return DecoratedInterval(interval, decoration)
-
-end
-
-doc"""
-`parse_interval_string` deals with strings of the form `"[3.5, 7.2]"`
-"""
-function parse_interval_string(T, s::AbstractString)
-    if !(contains(s, "["))  # string like "3.1"
-
-        expr = parse(s)
-
-        # after removing support for Julia 0.4, can simplify
-        # make_interval to just accept two expressions
-
-        val = make_interval(T, expr, [expr])   # use tryparse?
-        return eval(val)
-    end
-
-    # match string of form [a, b]_dec:
-    m = match(r"\[(.*),(.*)\]", s)
-
-    if m != nothing  # matched
-        lo, hi = m.captures
-
-    else
-
-        m = match(r"\[(.*)\]", s)  # string like "[1]"
-
-        if m == nothing
-            throw(ArgumentError("Unable to process string $s as interval"))
-        end
-
-        lo = m.captures[1]
-        hi = lo
-
-    end
-
-    expr1 = parse(lo)
-    expr2 = parse(hi)
-
-    interval = eval(make_interval(T, expr1, [expr2]))
-
-    return interval
-
-end
-
 
 # Floating point intervals:
 
 convert{T<:AbstractFloat}(::Type{Interval{T}}, x::AbstractString) =
-    parse_interval_string(T, x)
+    parse(Interval{T}, x)
 
 function convert{T<:AbstractFloat, S<:Real}(::Type{Interval{T}}, x::S)
     Interval{T}( T(x, RoundDown), T(x, RoundUp) )

--- a/src/intervals/conversion.jl
+++ b/src/intervals/conversion.jl
@@ -100,7 +100,7 @@ function convert{T<:AbstractFloat}(::Type{Interval{T}}, x::Float64)
     II = convert(Interval{T}, rationalize(x))
     # This prevents that rationalize(x) returns a zero when x is very small
     if x != zero(x) && II == zero(Interval{T})
-        II = convert(Interval{T}, string(x))
+        II = Interval{T}(x)
     end
     II
 end

--- a/src/intervals/conversion.jl
+++ b/src/intervals/conversion.jl
@@ -29,9 +29,13 @@ doc"""
 """
 function parse_interval_string(T, s::AbstractString)
     if !(contains(s, "["))  # string like "3.1"
+        expr = parse(s)
 
-        val = eval(parse(s))   # use tryparse?
-        return convert(Interval{T}, val)
+        # after removing support for Julia 0.4, can simplify
+        # make_interval to just accept two expressions
+        
+        val = make_interval(T, expr, [expr])   # use tryparse?
+        return eval(val)
     end
 
     m = match(r"\[(.*),(.*)\]", s)  # string like "[1, 2]"
@@ -44,16 +48,15 @@ function parse_interval_string(T, s::AbstractString)
             throw(ArgumentError("Unable to process string $x as interval"))
         end
 
-        val = eval(parse(m.captures[1]))
-        return convert(Interval{T}, val)
+        expr = parse(m.captures[1])
+        return eval(make_interval(T, expr, [expr]))
 
     end
 
-    val1 = eval(parse(m.captures[1]))
-    val2 = eval(parse(m.captures[2]))
+    expr1 = eval(parse(m.captures[1]))
+    expr2 = eval(parse(m.captures[2]))
 
-    return Interval(convert(Interval{T}, val1).lo,
-                    convert(Interval{T}, val2).hi)
+    return eval(make_interval(T, expr1, [expr2]))
 end
 
 

--- a/src/intervals/conversion.jl
+++ b/src/intervals/conversion.jl
@@ -26,14 +26,18 @@ function parse_decorated_string(T, s::AbstractString)
 
     end
 
-    interval_string, decoration = m.captures
+    interval_string, decoration_string = m.captures
     interval = parse_interval_string(T, interval_string)
 
-    if decoration == nothing
-        decoration = "_com"
+    # type unstable:
+    if decoration_string == nothing
+        decoration_string = "_com"
     end
 
-    return DecoratedInterval(interval, decorations[decoration[2:end]])
+    decoration_symbol = Symbol(decoration_string[2:end])
+    decoration = getfield(ValidatedNumerics, decoration_symbol)
+
+    return DecoratedInterval(interval, decoration)
 
 end
 

--- a/src/intervals/conversion.jl
+++ b/src/intervals/conversion.jl
@@ -67,7 +67,7 @@ function parse_interval_string(T, s::AbstractString)
         m = match(r"\[(.*)\]", s)  # string like "[1]"
 
         if m == nothing
-            throw(ArgumentError("Unable to process string $x as interval"))
+            throw(ArgumentError("Unable to process string $s as interval"))
         end
 
         lo = m.captures[1]

--- a/src/intervals/macros.jl
+++ b/src/intervals/macros.jl
@@ -78,6 +78,8 @@ and making each literal (0.1, 1, etc.) into a corresponding interval constructio
 by calling `transform`."""
 
 function make_interval(T, expr1, expr2)
+    @show expr1
+    @show expr2
     expr1 = transform(expr1, :convert, :(Interval{$T}))
 
     if isempty(expr2)  # only one argument

--- a/src/intervals/macros.jl
+++ b/src/intervals/macros.jl
@@ -35,12 +35,13 @@ end
 doc"""`transform` transforms a string by applying the function `f` and type
 `T` to each argument, i.e. `:(x+y)` is transformed to `:(f(T, x) + f(T, y))`
 """
-transform(x, f, T) = :($f($(esc(T)), $(esc(x))))   # use if x is not an expression
+transform(x::Symbol, f, T) = :($f($T, $(esc(x))))   # use if x is not an expression
+transform(x, f, T) = :($f($T, $x))   # use if x is not an
 
 function transform(expr::Expr, f::Symbol, T)
 
     if expr.head in ( :(.), :ref )   # of form  a.lo  or  a[i]
-        return :($f(esc(T)), $(esc(expr)))
+        return :($f($T, $(esc(expr))))
     end
 
     new_expr = copy(expr)
@@ -58,7 +59,7 @@ function transform(expr::Expr, f::Symbol, T)
     end
 
     if expr.head == :macrocall  # handles BigInts etc.
-        return :($f($(esc(T)), $(esc(expr))))  # hack: pass straight through
+        return :($f($T, $(esc(expr))))  # hack: pass straight through
     end
 
     for (i, arg) in enumerate(expr.args)
@@ -78,8 +79,8 @@ and making each literal (0.1, 1, etc.) into a corresponding interval constructio
 by calling `transform`."""
 
 function make_interval(T, expr1, expr2)
-    @show expr1
-    @show expr2
+    # @show expr1, expr2
+    
     expr1 = transform(expr1, :convert, :(Interval{$T}))
 
     if isempty(expr2)  # only one argument

--- a/src/parsing.jl
+++ b/src/parsing.jl
@@ -1,0 +1,71 @@
+
+function parse{T}(::Type{DecoratedInterval{T}, s::AbstractString)
+    m = match(r"(\[.*\])(\_.*)?", s)
+
+    if m == nothing  # matched
+        throw(ArgumentError("Unable to process string $x as decorated interval"))
+
+    end
+
+    interval_string, decoration_string = m.captures
+    interval = parse(Interval{T}, interval_string)
+
+    # type unstable:
+    if decoration_string == nothing
+        decoration_string = "_com"
+    end
+
+    decoration_symbol = Symbol(decoration_string[2:end])
+    decoration = getfield(ValidatedNumerics, decoration_symbol)
+
+    return DecoratedInterval(interval, decoration)
+
+end
+
+doc"""
+    parse{T}(Interval{T}, s::AbstractString)
+
+Parse a string as an interval. Formats allowed include:
+- "1"
+- "[1]"
+- "[3.5, 7.2]"
+"""
+function parse{T}(::Type{Interval{T}}, s::AbstractString)
+    if !(contains(s, "["))  # string like "3.1"
+
+        expr = parse(s)
+
+        # after removing support for Julia 0.4, can simplify
+        # make_interval to just accept two expressions
+
+        val = make_interval(T, expr, [expr])   # use tryparse?
+        return eval(val)
+    end
+
+    # match string of form [a, b]_dec:
+    m = match(r"\[(.*),(.*)\]", s)
+
+    if m != nothing  # matched
+        lo, hi = m.captures
+
+    else
+
+        m = match(r"\[(.*)\]", s)  # string like "[1]"
+
+        if m == nothing
+            throw(ArgumentError("Unable to process string $s as interval"))
+        end
+
+        lo = m.captures[1]
+        hi = lo
+
+    end
+
+    expr1 = parse(lo)
+    expr2 = parse(hi)
+
+    interval = eval(make_interval(T, expr1, [expr2]))
+
+    return interval
+
+end

--- a/src/parsing.jl
+++ b/src/parsing.jl
@@ -1,5 +1,5 @@
 
-function parse{T}(::Type{DecoratedInterval{T}, s::AbstractString)
+function parse{T}(::Type{DecoratedInterval{T}}, s::AbstractString)
     m = match(r"(\[.*\])(\_.*)?", s)
 
     if m == nothing  # matched

--- a/src/parsing.jl
+++ b/src/parsing.jl
@@ -1,4 +1,11 @@
+# Functions to parse strings to intervals
 
+doc"""
+    parse{T}(DecoratedInterval{T}, s::AbstractString)
+
+Parse a string of the form `"[a, b]_dec"` as a `DecoratedInterval`
+with decoration `dec`.
+"""
 function parse{T}(::Type{DecoratedInterval{T}}, s::AbstractString)
     m = match(r"(\[.*\])(\_.*)?", s)
 
@@ -29,6 +36,7 @@ Parse a string as an interval. Formats allowed include:
 - "1"
 - "[1]"
 - "[3.5, 7.2]"
+- "[-0x1.3p-1, 2/3]"  # use numerical expressions
 """
 function parse{T}(::Type{Interval{T}}, s::AbstractString)
     if !(contains(s, "["))  # string like "3.1"

--- a/test/decoration_tests/decoration_tests.jl
+++ b/test/decoration_tests/decoration_tests.jl
@@ -51,10 +51,10 @@ using ValidatedNumerics
     @test @decorated(-3, 2)^Interval(0.0, 1.0) == DecoratedInterval(0.0,2.0, trv)
     @test @decorated(-3, 2)^@decorated(0.0, 1.0) == DecoratedInterval(0.0,2.0, trv)
     @test @decorated(-3, 2)^Interval(-1.0, 1.0) == DecoratedInterval(0.0,Inf, trv)
-    @test @decorated(-3, 2)^@decorated(-1.0, 1.0) == DecoratedInterval(0.0,Inf, trv)
+    @test @decorated(-3, 2)^@decorated(-1.0, 1.0) == DecoratedInterval(0.0, Inf, trv)
 end
 
-@testset("Convert string to DecoratedInterval") begin
+@testset "Convert string to DecoratedInterval" begin
     @test convert(DecoratedInterval{Float64}, "[1,2]") ==
                     DecoratedInterval(Interval(1, 2), com)
 

--- a/test/decoration_tests/decoration_tests.jl
+++ b/test/decoration_tests/decoration_tests.jl
@@ -62,6 +62,3 @@ end
                         DecoratedInterval(Interval(1, 2), dac)
 
 end
-
-
-end

--- a/test/decoration_tests/decoration_tests.jl
+++ b/test/decoration_tests/decoration_tests.jl
@@ -53,3 +53,15 @@ using ValidatedNumerics
     @test @decorated(-3, 2)^Interval(-1.0, 1.0) == DecoratedInterval(0.0,Inf, trv)
     @test @decorated(-3, 2)^@decorated(-1.0, 1.0) == DecoratedInterval(0.0,Inf, trv)
 end
+
+@testset("Convert string to DecoratedInterval") begin
+    @test convert(DecoratedInterval{Float64}, "[1,2]") ==
+                    DecoratedInterval(Interval(1, 2), com)
+
+    @test convert(DecoratedInterval{Float64}, "[1,2]_dac") ==
+                        DecoratedInterval(Interval(1, 2), dac)
+
+end
+
+
+end

--- a/test/interval_tests/construction.jl
+++ b/test/interval_tests/construction.jl
@@ -263,7 +263,5 @@ setprecision(Interval, Float64)
     @test I"[1, 2]" == @interval("[1, 2]")
     @test I"[2/3, 1.1]" == @interval("[2/3, 1.1]") == Interval(0.6666666666666666, 1.1)
     @test I"[1]" == @interval("[1]") == Interval(1.0, 1.0)
-    @test I"[-0x1.3p-1, 2/3]") == @interval("[-0x1.3p-1, 2/3]") == Interval(-0.59375, 0.6666666666666667)]
-
-
+    @test I"[-0x1.3p-1, 2/3]" == @interval("[-0x1.3p-1, 2/3]") == Interval(-0.59375, 0.6666666666666667)
 end

--- a/test/interval_tests/construction.jl
+++ b/test/interval_tests/construction.jl
@@ -117,9 +117,8 @@ using ValidatedNumerics
     a = @interval("[0.1, 0.2]")
     b = @interval(0.1, 0.2)
 
-    @test a ⊆ b
+    @test a == b
 
-    @test_throws ArgumentError @interval("[0.1]")
     @test_throws ArgumentError @interval("[0.1, 0.2")
 
 
@@ -265,6 +264,6 @@ setprecision(Interval, Float64)
     @test I"[2/3, 1.1]" == @interval("[2/3, 1.1]") == Interval(0.6666666666666666, 1.1)
     @test I"[1]" == @interval("[1]") == Interval(1.0, 1.0)
     @test I"[-0x1.3p-1, 2/3]") == @interval("[-0x1.3p-1, 2/3]") == Interval(-0.59375, 0.6666666666666667)]
-    
+
 
 end

--- a/test/interval_tests/construction.jl
+++ b/test/interval_tests/construction.jl
@@ -255,3 +255,16 @@ end
     @test isnan(a.lo) && isnan(a.hi)
 
 end
+
+# issue 206:
+
+setprecision(Interval, Float64)
+
+@testset "Interval strings" begin
+    @test I"[1, 2]" == @interval("[1, 2]")
+    @test I"[2/3, 1.1]" == @interval("[2/3, 1.1]") == Interval(0.6666666666666666, 1.1)
+    @test I"[1]" == @interval("[1]") == Interval(1.0, 1.0)
+    @test I"[-0x1.3p-1, 2/3]") == @interval("[-0x1.3p-1, 2/3]") == Interval(-0.59375, 0.6666666666666667)]
+    
+
+end


### PR DESCRIPTION
Towards #206.

Currently implemented:
- `@interval("[1]")`
- `@interval("[-0x1.3p-1, 2/3]")`
- `convert(DecoratedInterval{Float64}, "[1, 2]_dac")`