### PR TITLE
Rounding modes using traits

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,8 @@
+<<<<<<< 640cbad0fc93195d13d257496fd1d4f4b185ceeb
 julia 0.5
+=======
+julia 0.4
+>>>>>>> Update CRlibm in REQUIRE
 CRlibm 0.5
 Compat 0.7.11
 StaticArrays 0.3

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,8 +1,4 @@
-<<<<<<< 640cbad0fc93195d13d257496fd1d4f4b185ceeb
 julia 0.5
-=======
-julia 0.4
->>>>>>> Update CRlibm in REQUIRE
 CRlibm 0.5
 Compat 0.7.11
 StaticArrays 0.3

--- a/src/ValidatedNumerics.jl
+++ b/src/ValidatedNumerics.jl
@@ -4,7 +4,7 @@ __precompile__(true)
 
 module ValidatedNumerics
 
-using CRlibm
+import CRlibm
 using Compat
 using StaticArrays
 using ForwardDiff

--- a/src/intervals/arithmetic.jl
+++ b/src/intervals/arithmetic.jl
@@ -159,12 +159,6 @@ if VERSION >= v"0.6.0-dev.1024"
     const filter = Iterators.filter
 end
 
-if VERSION < v"0.5.0-dev+1279"
-    min(x) = x
-    max(x) = x
-end
-
-
 function min_ignore_nans(args...)
     min(filter(x->!isnan(x), args)...)
 end
@@ -319,7 +313,7 @@ function mid{T}(a::Interval{T})
 
     a.lo == -∞ && return nextfloat(a.lo)
     a.hi == +∞ && return prevfloat(a.hi)
-    
+
     (a.lo + a.hi) / 2  # rounds to nearest
 end
 

--- a/src/intervals/functions.jl
+++ b/src/intervals/functions.jl
@@ -14,6 +14,9 @@ end
 
 # Integer power:
 
+# overwrite new behaviour for small integer powers:
+^{p}(x::ValidatedNumerics.Interval, ::Type{Val{p}}) = x^p
+
 function ^(a::Interval{BigFloat}, n::Integer)
     isempty(a) && return a
     n == 0 && return one(a)

--- a/src/intervals/functions.jl
+++ b/src/intervals/functions.jl
@@ -15,7 +15,7 @@ end
 # Integer power:
 
 # overwrite new behaviour for small integer powers:
-^{p}(x::ValidatedNumerics.Interval, ::Type{Val{p}}) = x^p
+# ^{p}(x::ValidatedNumerics.Interval, ::Type{Val{p}}) = x^p
 
 function ^(a::Interval{BigFloat}, n::Integer)
     isempty(a) && return a

--- a/src/intervals/precision.jl
+++ b/src/intervals/precision.jl
@@ -22,6 +22,14 @@ function big53(a::Interval{Float64})
     end
 end
 
+function big53(x::Float64)
+    # BigFloat(x, 53)  # in Julia v0.6
+
+    setprecision(53) do
+        BigFloat(x)
+    end
+end
+
 
 setprecision(::Type{Interval}, ::Type{Float64}) = parameters.precision_type = Float64
 # does not change the BigFloat precision

--- a/src/intervals/precision.jl
+++ b/src/intervals/precision.jl
@@ -85,44 +85,13 @@ Base.float{T}(::Type{Rational{T}}) = typeof(float(one(Rational{T})))
 
 # Use that type for rounding with rationals, e.g. for sqrt:
 
-if VERSION < v"0.5.0-dev+1182"
-
-    function Base.with_rounding{T}(f::Function, ::Type{Rational{T}},
-        rounding_mode::RoundingMode)
-        setrounding(f, float(Rational{T}), rounding_mode)
-    end
-
-else
-    function Base.setrounding{T}(f::Function, ::Type{Rational{T}},
-        rounding_mode::RoundingMode)
-        setrounding(f, float(Rational{T}), rounding_mode)
-    end
+function Base.setrounding{T}(f::Function, ::Type{Rational{T}},
+    rounding_mode::RoundingMode)
+    setrounding(f, float(Rational{T}), rounding_mode)
 end
+
 
 
 float{T}(x::Interval{T}) = convert(Interval{float(T)}, x)  # https://github.com/dpsanders/ValidatedNumerics.jl/issues/174
-
-## Change type of interval rounding:
-
-
-doc"""`rounding(Interval)` returns the current interval rounding mode.
-There are two possible rounding modes:
-
-- :narrow  -- changes the floating-point rounding mode to `RoundUp` and `RoundDown`.
-This gives the narrowest possible interval.
-
-- :wide -- Leaves the floating-point rounding mode in `RoundNearest` and uses
-`prevfloat` and `nextfloat` to achieve directed rounding. This creates an interval of width 2`eps`.
-"""
-
-rounding(::Type{Interval}) = parameters.rounding
-
-function setrounding(::Type{Interval}, mode)
-    if mode ∉ [:wide, :narrow]
-        throw(ArgumentError("Only possible interval rounding modes are `:wide` and `:narrow`"))
-    end
-
-    parameters.rounding = mode  # a symbol
-end
 
 big{T}(x::Interval{T}) = convert(Interval{BigFloat}, x)

--- a/src/intervals/rounding.jl
+++ b/src/intervals/rounding.jl
@@ -30,7 +30,7 @@ immutable RoundingType{T} end
     zero{T<:AbstractFloat}(a::Interval{T}, ::RoundingMode) = zero(T)
     zero{T<:AbstractFloat}(::Type{T}, ::RoundingMode) = zero(T)
 
-    convert(::Type{BigFloat}, x, rounding_mode::RoundingMode) = setrounding(BigFloat, rounding_mode) do
+    convert(::Type{BigFloat}, x, rounding_mode::RoundingMode) = (BigFloat, rounding_mode) do
         convert(BigFloat, x)
     end
 

--- a/src/intervals/rounding.jl
+++ b/src/intervals/rounding.jl
@@ -166,10 +166,10 @@ function setrounding(::Type{Interval}, rounding_type::Symbol)
 
         @eval $f{T<:AbstractFloat}(a::T, b::T, r::RoundingMode) = $f($rounding_object, a, b, r)
 
-        @eval $f(x::Real, y::Real, r::RoundingMode) = $f(float(x), float(y), r)
+        # @eval $f(x::, y::Real, r::RoundingMode) = $f(float(x), float(y), r)
     end
 
-    @eval ^{T<:AbstractFloat, S<:Real}(a::T, b::S, r::RoundingMode) = ^($rounding_object, a, b, r)
+    @eval ^{T<:AbstractFloat, S<:Real}(a::T, b::S, r::RoundingMode) = ^($rounding_object, promote(a, b)..., r)
 
     # unary functions:
     for f in vcat(CRlibm.functions,

--- a/src/intervals/rounding.jl
+++ b/src/intervals/rounding.jl
@@ -26,7 +26,7 @@ In Julia v0.6, but *not* in Julia v0.5, this will automatically redefine all rel
 
 doc"""Choose rounding mode based on environment variable"""
 
-immutable IntervalRounding{T<:Symbol} end
+immutable IntervalRounding{T} end
 
 # Functions that are the same for all rounding types:
 @eval begin

--- a/src/intervals/rounding.jl
+++ b/src/intervals/rounding.jl
@@ -136,23 +136,25 @@ for mode in (:Down, :Up) #, T in (:Float64)
                                     a::T, ::RoundingMode) = $f(a)
 
     end
+end
 
 
-function setrounding(::Type{Interval}, mode::Symbol)
-    mode2 = Meta.quot(mode)
+function setrounding(::Type{Interval}, mode1::Symbol)
+    mode2 = Meta.quot(mode1)
     # binary:
 
     for f in (:+, :-, :*, :/, :^, :atan2)
-        @eval $f{T<:AbstractFloat}(a::T, b::T, $mode1) = $f(RoundingType{$mode2}, a, b, $mode1)
+        @eval $f{T<:AbstractFloat}(a::T, b::T, $mode1) = $f(RoundingType{$mode2}(), a, b, $mode1)
     end
 
     for f in (:sqrt, :inv, :tanh, :asinh, :acosh, :atanh)
-        @eval $f{T<:AbstractFloat}(a::T, $mode1) = $f(RoundingType{$mode2}, a, $mode1)
+        @eval $f{T<:AbstractFloat}(a::T, $mode1) = $f(RoundingType{$mode2}(), a, $mode1)
     end
 
     for f in CRlibm.functions
-        @eval $f{T<:AbstractFloat}(a::T, $mode1) = $f(RoundingType{$mode2}, a, $mode1)
+        @eval $f{T<:AbstractFloat}(a::T, $mode1) = $f(RoundingType{$mode2}(), a, $mode1)
     end
 end
+
 
 setrounding(Interval, :correct)

--- a/src/intervals/rounding.jl
+++ b/src/intervals/rounding.jl
@@ -166,7 +166,7 @@ function setrounding(::Type{Interval}, rounding_type::Symbol)
 
         @eval $f{T<:AbstractFloat}(a::T, b::T, r::RoundingMode) = $f($rounding_object, a, b, r)
 
-        @eval $f(x::AbstractFloat, y::Real, r::RoundingMode) = $f(float(x), float(y), r)
+        @eval $f(x::Real, y::Real, r::RoundingMode) = $f(float(x), float(y), r)
     end
 
     @eval ^{T<:AbstractFloat, S<:Real}(a::T, b::S, r::RoundingMode) = ^($rounding_object, a, b, r)

--- a/src/intervals/rounding.jl
+++ b/src/intervals/rounding.jl
@@ -24,8 +24,7 @@ In Julia v0.6, but *not* in Julia v0.5, this will automatically redefine all rel
 =#
 
 
-doc"""Choose rounding mode based on environment variable"""
-
+doc"""Interval rounding trait type"""
 immutable IntervalRounding{T} end
 
 # Functions that are the same for all rounding types:

--- a/src/intervals/rounding.jl
+++ b/src/intervals/rounding.jl
@@ -30,9 +30,10 @@ immutable RoundingType{T} end
     zero{T<:AbstractFloat}(a::Interval{T}, ::RoundingMode) = zero(T)
     zero{T<:AbstractFloat}(::Type{T}, ::RoundingMode) = zero(T)
 
-    convert(::Type{BigFloat}, x, rounding_mode::RoundingMode) = (BigFloat, rounding_mode) do
-        convert(BigFloat, x)
-    end
+    convert(::Type{BigFloat}, x, rounding_mode::RoundingMode) =
+        setrounding(BigFloat, rounding_mode) do
+            convert(BigFloat, x)
+        end
 
     parse{T}(::Type{T}, x, rounding_mode::RoundingMode) = setrounding(T, rounding_mode) do
         parse(T, x)

--- a/src/intervals/rounding.jl
+++ b/src/intervals/rounding.jl
@@ -117,7 +117,7 @@ for mode in (:Down, :Up) #, T in (:Float64)
                                     a::T, $mode1) = $directed($f(a))
 
         @eval $f{T<:AbstractFloat}(::RoundingType{:none},
-                                    a::T, ::RoundingMode) = $f(a)
+                                    a::T, $mode1) = $f(a)
 
 
     end
@@ -133,7 +133,7 @@ for mode in (:Down, :Up) #, T in (:Float64)
                                     a::T, $mode1) = $directed($f(a))
 
         @eval $f{T<:AbstractFloat}(::RoundingType{:none},
-                                    a::T, ::RoundingMode) = $f(a)
+                                    a::T, $mode1) = $f(a)
 
     end
 end

--- a/src/intervals/rounding.jl
+++ b/src/intervals/rounding.jl
@@ -45,6 +45,9 @@ immutable RoundingType{T} end
 
 end
 
+# overwrite behaviour for small integer powers:
+^{p}(x::ValidatedNumerics.Interval, ::Type{Val{p}}) = x^p
+
 # no-ops for rational rounding:
 for f in (:+, :-, :*, :/)
     @eval $f{T<:Rational}(a::T, b::T, ::RoundingMode) = $f(a, b)

--- a/src/intervals/rounding.jl
+++ b/src/intervals/rounding.jl
@@ -13,12 +13,12 @@ The current allowed rounding types are
 - :fast     # fast rounding by prevfloat and nextfloat  (slightly wider than needed)
 - :none     # no rounding at all (for speed, but forgoes any pretense at being rigorous)
 
-The function `setrounding(Interval, rounding_type)` then defines rounded functions
-*without* an explicit rounding type, e.g.
+The function `setrounding(Interval, rounding_type)` then defines rounded
+ functions *without* an explicit rounding type, e.g.
 
 sin(x, r::RoundingMode) = sin(IntervalRounding{:correct}, x, r)
 
-These are overwritten when  `setrounding(Interval, rounding_type)` is called again.
+These are overwritten when `setrounding(Interval, rounding_type)` is called again.
 
 In Julia v0.6, but *not* in Julia v0.5, this will automatically redefine all relevant functions, in particular those used in +(a::Interval, b::Interval) etc., so that all interval functions will automatically work with the correct interval rounding type.
 =#

--- a/src/intervals/rounding.jl
+++ b/src/intervals/rounding.jl
@@ -2,79 +2,157 @@
 # E.g.  +(a, b, RoundDown)
 # Some, like sin(a, RoundDown)  are already defined in CRlibm
 
+# Rounding types:
+# - :correct  # correct rounding
+# - :fast     # fast rounding by prevfloat and nextfloat  (slightly wider than needed)
+# - :none     # no rounding at all for speed
 
-import Base: +, -, *, /, sin, sqrt, inv, ^, zero, convert, parse
+# "Traits-based" design:
+# Define functions like
+# sin(::RoundingType{:correct}, x, ::RoundingMode)
+# sin(::RoundingType{:fast}, x, ::RoundingMode)
+# sin(::RoundingType{:none}, x, ::RoundingMode)
 
-# unary minus:
--{T<:AbstractFloat}(a::T, ::RoundingMode) = -a  # ignore rounding
+# Then define e.g.
+# sin(x, r::RoundingMode) = sin(RoundingType{:correct}, x, r)
 
-# zero:
-zero{T<:AbstractFloat}(a::Interval{T}, ::RoundingMode) = zero(T)
-zero{T<:AbstractFloat}(::Type{T}, ::RoundingMode) = zero(T)
 
-convert(::Type{BigFloat}, x, rounding_mode::RoundingMode) = setrounding(BigFloat, rounding_mode) do
-    convert(BigFloat, x)
+doc"""Choose rounding mode based on environment variable"""
+
+immutable RoundingType{T} end
+
+
+# Functions that are the same for all rounding types:
+@eval begin
+    # unary minus:
+    -{T<:AbstractFloat}(a::T, ::RoundingMode) = -a  # ignore rounding
+
+    # zero:
+    zero{T<:AbstractFloat}(a::Interval{T}, ::RoundingMode) = zero(T)
+    zero{T<:AbstractFloat}(::Type{T}, ::RoundingMode) = zero(T)
+
+    convert(::Type{BigFloat}, x, rounding_mode::RoundingMode) = setrounding(BigFloat, rounding_mode) do
+        convert(BigFloat, x)
+    end
+
+    parse{T}(::Type{T}, x, rounding_mode::RoundingMode) = setrounding(T, rounding_mode) do
+        parse(T, x)
+    end
+
+
+    sqrt{T<:Rational}(a::T, rounding_mode::RoundingMode) = setrounding(float(T), rounding_mode) do
+        sqrt(float(a))
+    end
+
 end
-
-parse{T}(::Type{T}, x, rounding_mode::RoundingMode) = setrounding(T, rounding_mode) do
-    parse(T, x)
-end
-
 
 # no-ops for rational rounding:
 for f in (:+, :-, :*, :/)
     @eval $f{T<:Rational}(a::T, b::T, ::RoundingMode) = $f(a, b)
 end
 
-sqrt{T<:Rational}(a::T, rounding_mode::RoundingMode) = setrounding(float(T), rounding_mode) do
-    sqrt(float(a))
-end
 
 
-
-for mode in (:Down, :Up)
+for mode in (:Down, :Up) #, T in (:Float64)
 
     mode1 = Expr(:quote, mode)
     mode1 = :(::RoundingMode{$mode1})
 
     mode2 = Symbol("Round", mode)
 
+    if mode == :Down
+        directed = :prevfloat
+    else
+        directed = :nextfloat
+    end
 
-    for f in (:+, :-, :*, :/,
-                :atan2)
 
-        @eval begin
-            function $f{T<:AbstractFloat}(a::T, b::T, $mode1)
-                setrounding(T, $mode2) do
-                    $f(a, b)
+    # binary functions:
+    for f in (:+, :-, :*, :/, :atan2)
+
+        @eval function $f{T<:AbstractFloat}(::RoundingType{:correct},
+                                            a::T, b::T, $mode1)
+                    setrounding(T, $mode2) do
+                        $f(a, b)
+                    end
                 end
-            end
-        end
-    end
 
-    @eval begin
-        function ^{T<:AbstractFloat,S}(a::T, b::S, $mode1)
-            setrounding(T, $mode2) do
-                ^(a, b)
-            end
-        end
+        @eval $f{T<:AbstractFloat}(::RoundingType{:fast},
+                                    a::T, b::T, $mode1) = $directed($f(a, b))
+
+        @eval $f{T<:AbstractFloat}(::RoundingType{:none},
+                                    a::T, b::T, $mode1) = $f(a, b)
+
     end
 
 
-    for f in (:sqrt, :inv,
-            :tanh, :asinh, :acosh, :atanh)   # these functions not in CRlibm
-        @eval begin
-            function $f{T<:AbstractFloat}(a::T, $mode1)
-                setrounding(T, $mode2) do
-                    $f(a)
-                end
-            end
-        end
+    # power:
+
+    @eval function ^{T<:AbstractFloat,S}(::RoundingType{:correct},
+                                        a::T, b::S, $mode1)
+                  setrounding(T, $mode2) do
+                      ^(a, b)
+                  end
+           end
+
+    @eval ^{T<:AbstractFloat,S}(::RoundingType{:fast},
+                                a::T, b::S, $mode1) = $directed(a^b)
+
+    @eval ^{T<:AbstractFloat,S}(::RoundingType{:none},
+                                a::T, b::S, $mode1) = a^b
+
+
+    # functions not in CRlibm:
+    for f in (:sqrt, :inv, :tanh, :asinh, :acosh, :atanh)
+
+        @eval function $f{T<:AbstractFloat}(::RoundingType{:correct},
+                                            a::T, $mode1)
+                            setrounding(T, $mode2) do
+                                $f(a)
+                            end
+               end
+
+
+        @eval $f{T<:AbstractFloat}(::RoundingType{:fast},
+                                    a::T, $mode1) = $directed($f(a))
+
+        @eval $f{T<:AbstractFloat}(::RoundingType{:none},
+                                    a::T, ::RoundingMode) = $f(a)
+
+
     end
 
+
+    # Functions defined in CRlibm
 
     for f in CRlibm.functions
-        @eval $f{T<:AbstractFloat}(a::T, $mode1) = CRlibm.$f(a, $mode2)
+        @eval $f{T<:AbstractFloat}(::RoundingType{:correct},
+                                a::T, $mode1) = CRlibm.$f(a, $mode2)
+
+        @eval $f{T<:AbstractFloat}(::RoundingType{:fast},
+                                    a::T, $mode1) = $directed($f(a))
+
+        @eval $f{T<:AbstractFloat}(::RoundingType{:none},
+                                    a::T, ::RoundingMode) = $f(a)
+
     end
 
+
+function setrounding(::Type{Interval}, mode::Symbol)
+    mode2 = Meta.quot(mode)
+    # binary:
+
+    for f in (:+, :-, :*, :/, :^, :atan2)
+        @eval $f{T<:AbstractFloat}(a::T, b::T, $mode1) = $f(RoundingType{$mode2}, a, b, $mode1)
+    end
+
+    for f in (:sqrt, :inv, :tanh, :asinh, :acosh, :atanh)
+        @eval $f{T<:AbstractFloat}(a::T, $mode1) = $f(RoundingType{$mode2}, a, $mode1)
+    end
+
+    for f in CRlibm.functions
+        @eval $f{T<:AbstractFloat}(a::T, $mode1) = $f(RoundingType{$mode2}, a, $mode1)
+    end
 end
+
+setrounding(Interval, :correct)

--- a/src/intervals/rounding.jl
+++ b/src/intervals/rounding.jl
@@ -154,7 +154,10 @@ for mode in (:Down, :Up)
 end
 
 doc"""
+    setrounding(Interval, rounding_type::Symbol)
+
 Set the rounding type used for all interval calculations on Julia v0.6 and above.
+Valid `rounding_type`s are `:correct`, `:fast` and `:none`.
 """
 function setrounding(::Type{Interval}, rounding_type::Symbol)
 

--- a/test/ITF1788_tests/libieeep1788_tests_bool.jl
+++ b/test/ITF1788_tests/libieeep1788_tests_bool.jl
@@ -28,7 +28,7 @@ using ValidatedNumerics
 #Preamble
 setprecision(53)
 setprecision(Interval, Float64)
-setrounding(Interval, :narrow)
+# setrounding(Interval, :narrow)
 
 facts("minimal_empty_test") do
     @fact isempty(∅) --> true

--- a/test/ITF1788_tests/libieeep1788_tests_cancel.jl
+++ b/test/ITF1788_tests/libieeep1788_tests_cancel.jl
@@ -28,7 +28,7 @@ using ValidatedNumerics
 #Preamble
 setprecision(53)
 setprecision(Interval, Float64)
-setrounding(Interval, :narrow)
+# setrounding(Interval, :narrow)
 
 facts("minimal_cancelPlus_test") do
     @fact cancelplus(Interval(-Inf, -1.0), ∅) --> entireinterval(Float64)

--- a/test/ITF1788_tests/libieeep1788_tests_elem.jl
+++ b/test/ITF1788_tests/libieeep1788_tests_elem.jl
@@ -28,7 +28,7 @@ using ValidatedNumerics
 #Preamble
 setprecision(53)
 setprecision(Interval, Float64)
-setrounding(Interval, :narrow)
+# setrounding(Interval, :narrow)
 
 facts("minimal_pos_test") do
     @fact +Interval(1.0, 2.0) --> Interval(1.0, 2.0)

--- a/test/ITF1788_tests/libieeep1788_tests_mul_rev.jl
+++ b/test/ITF1788_tests/libieeep1788_tests_mul_rev.jl
@@ -28,7 +28,7 @@ using ValidatedNumerics
 #Preamble
 setprecision(53)
 setprecision(Interval, Float64)
-setrounding(Interval, :narrow)
+# setrounding(Interval, :narrow)
 
 facts("minimal_mulRevToPair_test") do
 

--- a/test/ITF1788_tests/libieeep1788_tests_num.jl
+++ b/test/ITF1788_tests/libieeep1788_tests_num.jl
@@ -28,7 +28,7 @@ using ValidatedNumerics
 #Preamble
 setprecision(53)
 setprecision(Interval, Float64)
-setrounding(Interval, :narrow)
+# setrounding(Interval, :narrow)
 
 facts("minimal_inf_test") do
     @fact infimum(∅) --> Inf

--- a/test/ITF1788_tests/libieeep1788_tests_overlap.jl
+++ b/test/ITF1788_tests/libieeep1788_tests_overlap.jl
@@ -28,7 +28,7 @@ using ValidatedNumerics
 #Preamble
 setprecision(53)
 setprecision(Interval, Float64)
-setrounding(Interval, :narrow)
+# setrounding(Interval, :narrow)
 
 facts("minimal_overlap_test") do
 

--- a/test/ITF1788_tests/libieeep1788_tests_rec_bool.jl
+++ b/test/ITF1788_tests/libieeep1788_tests_rec_bool.jl
@@ -28,7 +28,7 @@ using ValidatedNumerics
 #Preamble
 setprecision(53)
 setprecision(Interval, Float64)
-setrounding(Interval, :narrow)
+# setrounding(Interval, :narrow)
 
 facts("minimal_isCommonInterval_test") do
     @fact iscommon(Interval(-27.0, -27.0)) --> true

--- a/test/ITF1788_tests/libieeep1788_tests_rev.jl
+++ b/test/ITF1788_tests/libieeep1788_tests_rev.jl
@@ -28,7 +28,7 @@ using ValidatedNumerics
 #Preamble
 setprecision(53)
 setprecision(Interval, Float64)
-setrounding(Interval, :narrow)
+# setrounding(Interval, :narrow)
 
 facts("minimal_sqrRev_test") do
 

--- a/test/ITF1788_tests/libieeep1788_tests_set.jl
+++ b/test/ITF1788_tests/libieeep1788_tests_set.jl
@@ -28,7 +28,7 @@ using ValidatedNumerics
 #Preamble
 setprecision(53)
 setprecision(Interval, Float64)
-setrounding(Interval, :narrow)
+# setrounding(Interval, :narrow)
 
 facts("minimal_intersection_test") do
     @fact Interval(1.0, 3.0) ∩ Interval(2.1, 4.0) --> Interval(2.1, 3.0)

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,3 +1,4 @@
 FactCheck 0.3
 Polynomials 0.0.5
 BaseTestNext
+Suppressor

--- a/test/interval_tests/consistency.jl
+++ b/test/interval_tests/consistency.jl
@@ -283,15 +283,15 @@ c = @interval(0.25, 4.0)
         @test precision(Interval) == (Float64, 100)
     end
 
-    @testset "Interval rounding tests" begin
-        setrounding(Interval, :wide)
-        @test rounding(Interval) == :wide
-
-        @test_throws ArgumentError setrounding(Interval, :hello)
-
-        setrounding(Interval, :narrow)
-        @test rounding(Interval) == :narrow
-    end
+    # @testset "Interval rounding tests" begin
+    #     setrounding(Interval, :wide)
+    #     @test rounding(Interval) == :wide
+    #
+    #     @test_throws ArgumentError setrounding(Interval, :hello)
+    #
+    #     setrounding(Interval, :narrow)
+    #     @test rounding(Interval) == :narrow
+    # end
 
     @testset "Interval power of an interval" begin
 

--- a/test/interval_tests/consistency.jl
+++ b/test/interval_tests/consistency.jl
@@ -284,12 +284,12 @@ c = @interval(0.25, 4.0)
     end
 
     # @testset "Interval rounding tests" begin
-    #     setrounding(Interval, :wide)
+    #     # setrounding(Interval, :wide)
     #     @test rounding(Interval) == :wide
     #
-    #     @test_throws ArgumentError setrounding(Interval, :hello)
+    #     @test_throws ArgumentError # setrounding(Interval, :hello)
     #
-    #     setrounding(Interval, :narrow)
+    #     # setrounding(Interval, :narrow)
     #     @test rounding(Interval) == :narrow
     # end
 

--- a/test/interval_tests/intervals.jl
+++ b/test/interval_tests/intervals.jl
@@ -11,3 +11,7 @@ include("loops.jl")
 include("complex.jl")
 include("parsing.jl")
 include("rounding_macros.jl")
+
+if VERSION >= v"0.6.0-dev.1671"  # PR https://github.com/JuliaLang/julia/pull/17057 fixing issue #265
+    include("rounding.jl")
+end

--- a/test/interval_tests/linear_algebra.jl
+++ b/test/interval_tests/linear_algebra.jl
@@ -17,12 +17,7 @@ b = [-2..2
 
     # Example from Moore et al., Introduction to Interval Analysis (2009), pg. 88:
 
-    if VERSION <= v"0.5"
     @test A \ b == [-5..5
                     -4..4]
-    else
-        @test_broken A \ b == [-5..5
-                               -4..4]
-                    end
 
 end

--- a/test/interval_tests/linear_algebra.jl
+++ b/test/interval_tests/linear_algebra.jl
@@ -17,7 +17,12 @@ b = [-2..2
 
     # Example from Moore et al., Introduction to Interval Analysis (2009), pg. 88:
 
-    @test_broken A \ b == [-5..5
+    if VERSION <= v"0.5"
+    @test A \ b == [-5..5
                     -4..4]
+    else
+        @test_broken A \ b == [-5..5
+                               -4..4]
+                    end
 
 end

--- a/test/interval_tests/linear_algebra.jl
+++ b/test/interval_tests/linear_algebra.jl
@@ -3,33 +3,21 @@ using Base.Test
 
 
 
-A =
-    [
-        @interval( 2, 4)    @interval(-2, 1) ;
-        @interval(-1, 2)    @interval( 2, 4)
-    ]
+A = [ 2..4   -2..1
+     -1..2    2..4]
 
-b =
-    [
-        @interval(-2, 2),
-        @interval(-2, 2)
-    ]
+b = [-2..2
+     -2..2]
 
 
 @testset "Linear algebra with intervals tests" begin
 
-    @test A * b ==
-        [
-            @interval(-12, 12),
-            @interval(-12, 12)
-        ]
+    @test A * b == [-12..12
+                    -12..12]
 
     # Example from Moore et al., Introduction to Interval Analysis (2009), pg. 88:
 
-    @test A \ b ==
-        [
-            @interval(-5, 5),
-            @interval(-4, 4)
-        ]
+    @test_broken A \ b == [-5..5
+                    -4..4]
 
 end

--- a/test/interval_tests/numeric.jl
+++ b/test/interval_tests/numeric.jl
@@ -4,7 +4,7 @@ using ValidatedNumerics
 using Base.Test
 
 setprecision(Interval, Float64)
-setrounding(Interval, :narrow)
+# setrounding(Interval, :narrow)
 
 
 @testset "Numeric tests" begin

--- a/test/interval_tests/numeric.jl
+++ b/test/interval_tests/numeric.jl
@@ -4,7 +4,7 @@ using ValidatedNumerics
 using Base.Test
 
 setprecision(Interval, Float64)
-# setrounding(Interval, :narrow)
+# # setrounding(Interval, :narrow)
 
 
 @testset "Numeric tests" begin
@@ -179,18 +179,18 @@ end
     @test round(@interval(-1.5, 0.1), RoundTiesToAway) == Interval(-2.0, 0.0)
     @test round(@interval(-2.5, 0.1), RoundTiesToAway) == Interval(-3.0, 0.0)
 
-    # :wide tests
-    setrounding(Interval, :wide)
-    setprecision(Interval, Float64)
-
-    a = @interval(-3.0, 2.0)
-    @test a == Interval(-3.0, 2.0)
-    @test a^3 == Interval(-27, 8)
-    @test Interval(-3,2)^3 == Interval(-27, 8)
-
-    @test Interval(-27.0, 8.0)^(1//3) == Interval(0, 2.0000000000000004)
-
-    setrounding(Interval, :narrow)
+    # # :wide tests
+    # # setrounding(Interval, :wide)
+    # setprecision(Interval, Float64)
+    #
+    # a = @interval(-3.0, 2.0)
+    # @test a == Interval(-3.0, 2.0)
+    # @test a^3 == Interval(-27, 8)
+    # @test Interval(-3,2)^3 == Interval(-27, 8)
+    #
+    # @test Interval(-27.0, 8.0)^(1//3) == Interval(0, 2.0000000000000004)
+    #
+    # # setrounding(Interval, :narrow)
 end
 
 @testset "Fast power" begin

--- a/test/interval_tests/rounding.jl
+++ b/test/interval_tests/rounding.jl
@@ -13,16 +13,24 @@ setdisplay(:full)
 
 setrounding(Interval, :correct)
 x = Interval(0.5)
-@test sin(x) == Interval(0.47942553860420295, 0.479425538604203)
+@testset "Correct rounding" begin
+    @test sin(x) == Interval(0.47942553860420295, 0.479425538604203)
+end
 
 setrounding(Interval, :fast)
-@test sin(x) == Interval(0.47942553860420295, 0.47942553860420306)
+@testset "Fast rounding" begin
+    @test sin(x) == Interval(0.47942553860420295, 0.47942553860420306)
+end
 
 setrounding(Interval, :none)
-@test sin(x) == Interval(0.479425538604203, 0.479425538604203)
+@testset "No rounding" begin
+    @test sin(x) == Interval(0.479425538604203, 0.479425538604203)
+end
 
 setrounding(Interval, :correct)
-@test sin(x) == Interval(0.47942553860420295, 0.479425538604203)
+@testset "Back to correct rounding" begin
+    @test sin(x) == Interval(0.47942553860420295, 0.479425538604203)
+end
 
 setdisplay(:standard)
 

--- a/test/interval_tests/rounding.jl
+++ b/test/interval_tests/rounding.jl
@@ -1,7 +1,8 @@
-
+using ValidatedNumerics
 using Base.Test
 
-@testset("Interval rounding") begin
+
+@testset "Interval rounding" begin
 
     x = Interval(0.5)
     @test sin(x) == Interval(0.47942553860420295, 0.479425538604203)

--- a/test/interval_tests/rounding.jl
+++ b/test/interval_tests/rounding.jl
@@ -1,0 +1,18 @@
+
+using Base.Test
+
+@testset("Interval rounding") begin
+
+    x = Interval(0.5)
+    @test sin(x) == Interval(0.47942553860420295, 0.479425538604203)
+
+    setrounding(Interval, :fast)
+    @test sin(x) == Interval(0.47942553860420295, 0.47942553860420306)
+
+    setrounding(Interval, :none)
+    @test sin(x) == Interval(0.479425538604203, 0.479425538604203)
+
+    setrounding(Interval, :correct)
+    @test sin(x) == Interval(0.47942553860420295, 0.479425538604203)
+
+end

--- a/test/interval_tests/rounding.jl
+++ b/test/interval_tests/rounding.jl
@@ -5,7 +5,7 @@ using Suppressor
 
 setdisplay(:full)
 
-@suppress begin
+#@suppress begin
 
 @testset "Interval rounding" begin
 
@@ -22,4 +22,4 @@ setdisplay(:full)
     @test sin(x) == Interval(0.47942553860420295, 0.479425538604203)
 
 end
-end
+#end

--- a/test/interval_tests/rounding.jl
+++ b/test/interval_tests/rounding.jl
@@ -1,6 +1,11 @@
 using ValidatedNumerics
 using Base.Test
 
+using Suppressor
+
+setdisplay(:full)
+
+@suppress begin
 
 @testset "Interval rounding" begin
 
@@ -16,4 +21,5 @@ using Base.Test
     setrounding(Interval, :correct)
     @test sin(x) == Interval(0.47942553860420295, 0.479425538604203)
 
+end
 end

--- a/test/interval_tests/rounding.jl
+++ b/test/interval_tests/rounding.jl
@@ -1,25 +1,30 @@
 using ValidatedNumerics
 using Base.Test
 
-using Suppressor
+# using Suppressor
 
 setdisplay(:full)
 
-#@suppress begin
+# @suppress begin
 
-@testset "Interval rounding" begin
+# @testset "Interval rounding" begin
 
-    x = Interval(0.5)
-    @test sin(x) == Interval(0.47942553860420295, 0.479425538604203)
+# NB: Due to "world age" problems, the following is not a @testset
 
-    setrounding(Interval, :fast)
-    @test sin(x) == Interval(0.47942553860420295, 0.47942553860420306)
+setrounding(Interval, :correct)
+x = Interval(0.5)
+@test sin(x) == Interval(0.47942553860420295, 0.479425538604203)
 
-    setrounding(Interval, :none)
-    @test sin(x) == Interval(0.479425538604203, 0.479425538604203)
+setrounding(Interval, :fast)
+@test sin(x) == Interval(0.47942553860420295, 0.47942553860420306)
 
-    setrounding(Interval, :correct)
-    @test sin(x) == Interval(0.47942553860420295, 0.479425538604203)
+setrounding(Interval, :none)
+@test sin(x) == Interval(0.479425538604203, 0.479425538604203)
 
-end
-#end
+setrounding(Interval, :correct)
+@test sin(x) == Interval(0.47942553860420295, 0.479425538604203)
+
+setdisplay(:standard)
+
+# end
+# end

--- a/test/root_finding_tests/findroots.jl
+++ b/test/root_finding_tests/findroots.jl
@@ -55,7 +55,7 @@ function_list = [
 
     for rounding_type in (:wide, :narrow)
         @testset "Interval rounding: $rounding_type" begin
-            setrounding(Interval, rounding_type)
+            # setrounding(Interval, rounding_type)
 
             for prec in ( (BigFloat,53), (BigFloat,256), (Float64,64) )
                 @testset "Precision: $prec" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,7 +7,6 @@ using Base.Test
 setdisplay(:full)
 
 include("interval_tests/intervals.jl")
-include("multidim_tests/multidim.jl")
 include("decoration_tests/decoration_tests.jl")
 
 # Display tests:
@@ -22,3 +21,5 @@ include("root_finding_tests/root_finding.jl")
 # ITF1788 tests
 
 include("ITF1788_tests/ITF1788_tests.jl")
+
+include("multidim_tests/multidim.jl")


### PR DESCRIPTION
This is an implementation of changing the global rounding mode using "traits".

Note that **actually changing the rounding mode for calculations works *only* on Julia v0.6**, since it depends on the solution to https://github.com/JuliaLang/julia/issues/265.

From the point of view of the user, it reduces to doing

```
setrounding(Interval, :correct)
```

I have not yet added tests.