### PR TITLE
Use CRlibm 0.5 that does not export functions

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,5 @@
 julia 0.4
-CRlibm 0.2.2 0.4
+CRlibm 0.5
 Compat 0.7.11
 FixedSizeArrays 0.1.2
 ForwardDiff 0.2.0

--- a/src/intervals/rounding.jl
+++ b/src/intervals/rounding.jl
@@ -72,4 +72,9 @@ for mode in (:Down, :Up)
         end
     end
 
+
+    for f in CRlibm.functions
+        @eval $f{T<:AbstractFloat}(a::T, $mode1) = CRlibm.$f(a, $mode2)
+    end
+
 end


### PR DESCRIPTION
CRlibm 0.5 (the latest release) no longer exports functions, so we define them explicitly in `rounding.jl`.

This is in preparation for #220, but should be included in v0.7.