### PR TITLE
Fix 1D Newton by checking correctly whether midpoint is exactly a root

### DIFF
--- a/src/root_finding/krawczyk.jl
+++ b/src/root_finding/krawczyk.jl
@@ -10,7 +10,8 @@ does not contain zero, and the second is the inverse of its derivative"""
 function guarded_derivative_midpoint{T}(f::Function, f_prime::Function, x::Interval{T})
 
     α = convert(T, 0.46875)   # close to 0.5, but exactly representable as a floating point
-    m = Interval( guarded_mid(f, x) )
+    # m = Interval( guarded_mid(f, x) )
+    m = Interval(mid(x))
 
     C = inv(f_prime(m))
 
@@ -70,7 +71,7 @@ function krawczyk{T}(f::Function, f_prime::Function, x::Interval{T}, level::Int=
 
     isempty(Kx ∩ x) && return Root{T}[]  # [(x, :none)]
 
-    if Kx ⪽ x  # isinterior 
+    if Kx ⪽ x  # isinterior
         debug && (print("Refining "); @show(x))
         return krawczyk_refine(f, f_prime, Kx, tolerance=tolerance, debug=debug)
     end

--- a/src/root_finding/krawczyk.jl
+++ b/src/root_finding/krawczyk.jl
@@ -10,7 +10,7 @@ does not contain zero, and the second is the inverse of its derivative"""
 function guarded_derivative_midpoint{T}(f::Function, f_prime::Function, x::Interval{T})
 
     α = convert(T, 0.46875)   # close to 0.5, but exactly representable as a floating point
-    m = Interval( guarded_mid(x) )
+    m = Interval( guarded_mid(f, x) )
 
     C = inv(f_prime(m))
 
@@ -70,12 +70,12 @@ function krawczyk{T}(f::Function, f_prime::Function, x::Interval{T}, level::Int=
 
     isempty(Kx ∩ x) && return Root{T}[]  # [(x, :none)]
 
-    if Kx ⪽ x
+    if Kx ⪽ x  # isinterior 
         debug && (print("Refining "); @show(x))
         return krawczyk_refine(f, f_prime, Kx, tolerance=tolerance, debug=debug)
     end
 
-    m = guarded_mid(x)
+    m = guarded_mid(f, x)
 
     debug && @show(x,m)
 

--- a/src/root_finding/krawczyk.jl
+++ b/src/root_finding/krawczyk.jl
@@ -17,7 +17,7 @@ function guarded_derivative_midpoint{T}(f::Function, f_prime::Function, x::Inter
 
     # Check that 0 is not in C; if so, consider another point rather than m
     i = 0
-    while zero(T) ∈ C
+    while zero(T) ∈ C || isempty(C)
         m = Interval( α*x.lo + (one(T)-α)*x.hi )
         C = inv(f_prime(m))
 

--- a/src/root_finding/newton.jl
+++ b/src/root_finding/newton.jl
@@ -4,10 +4,11 @@
 
 # What is this guarded_mid for? Shouldn't it be checking if f(m)==0?
 doc"""Returns the midpoint of the interval x, slightly shifted in case
-it is zero"""
-function guarded_mid{T}(x::Interval{T})
+the midpoint is an exact root"""
+function guarded_mid{T}(f, x::Interval{T})
     m = mid(x)
-    if m == zero(T)                     # midpoint exactly 0
+
+    if f(m) == 0                      # midpoint exactly a root
         α = convert(T, 0.46875)      # close to 0.5, but exactly representable as a floating point
         m = α*x.lo + (one(T)-α)*x.hi   # displace to another point in the interval
     end
@@ -19,7 +20,7 @@ end
 
 
 function N{T}(f::Function, x::Interval{T}, deriv::Interval{T})
-    m = guarded_mid(x)
+    m = guarded_mid(f, x)
     m = Interval(m)
 
     m - (f(m) / deriv)
@@ -85,7 +86,7 @@ function newton{T}(f::Function, f_prime::Function, x::Interval{T}, level::Int=0;
             return newton_refine(f, f_prime, Nx, tolerance=tolerance, debug=debug)
         end
 
-        m = guarded_mid(x)
+        m = guarded_mid(f, x)
 
         debug && @show(x,m)
 

--- a/test/root_finding_tests/findroots.jl
+++ b/test/root_finding_tests/findroots.jl
@@ -147,6 +147,19 @@ end
     end
 end
 
+@testset "Logistic function with Newton" begin
+    ∘(f, g) = x -> f(g(x))
+    iterate(f, n) = n == 1 ? f : f ∘ iterate(f, n-1)
+
+    f(x) = 4x*(1-x)  # logistic map
+
+    for n in 1:10
+        g = x -> iterate(f, n)(x) - x  # look for fixed points of f^n
+        roots = newton(g, 0..1)
+        @test length(roots) = 2^n
+    end
+end
+
 
 
 # Example of a function with a double root at 0 from Burden & Faires, 9th ed, p.84

--- a/test/root_finding_tests/findroots.jl
+++ b/test/root_finding_tests/findroots.jl
@@ -157,10 +157,10 @@ end
         g = x -> iterate(f, n)(x) - x  # look for fixed points of f^n
 
         roots = newton(g, 0..1)
-        @test length(roots) = 2^n
+        @test length(roots) == 2^n
 
         roots = krawczyk(g, 0..1)
-        @test length(roots) = 2^n
+        @test length(roots) == 2^n
 
     end
 end

--- a/test/root_finding_tests/findroots.jl
+++ b/test/root_finding_tests/findroots.jl
@@ -147,7 +147,7 @@ end
     end
 end
 
-@testset "Logistic function with Newton" begin
+@testset "Iterated logistic function fixed points" begin
     ∘(f, g) = x -> f(g(x))
     iterate(f, n) = n == 1 ? f : f ∘ iterate(f, n-1)
 
@@ -155,8 +155,13 @@ end
 
     for n in 1:10
         g = x -> iterate(f, n)(x) - x  # look for fixed points of f^n
+
         roots = newton(g, 0..1)
         @test length(roots) = 2^n
+
+        roots = krawczyk(g, 0..1)
+        @test length(roots) = 2^n
+
     end
 end
 


### PR DESCRIPTION
- Fixes Newton by correctly checking if a midpoint is exactly a root, and moving the midpoint a bit if it is.

- Fixes Krawczyk in the case that the midpoint has derivative 0.