### PR TITLE
Add bisection root-finder

### DIFF
--- a/src/root_finding/bisection.jl
+++ b/src/root_finding/bisection.jl
@@ -11,7 +11,7 @@ function bisection{T<:Union{Interval,IntervalBox}}(f, X::T; tolerance=1e-3, debu
     debug && @show X, image
 
     if !(zero(X) ⊆ image)
-        return Root{T}[]
+        return Root{typeof(X)}[]
     end
 
     if diam(X) < tolerance

--- a/src/root_finding/bisection.jl
+++ b/src/root_finding/bisection.jl
@@ -4,7 +4,7 @@ doc"""
 
 Find possible roots of the function `f` inside the `Interval` or `IntervalBox` `X`.
 """
-function bisection{T}(f, X::T; tolerance=1e-3, debug=false)
+function bisection{T<:Union{Interval,IntervalBox}}(f, X::T; tolerance=1e-3, debug=false)
 
     image = f(X)
 

--- a/src/root_finding/bisection.jl
+++ b/src/root_finding/bisection.jl
@@ -1,10 +1,15 @@
 
-function bisection{T}(f, X::Interval{T}; tolerance=1e-3)
+doc"""
+    bisection(f, X; tolerance=1e-3)
+
+Find possible roots of the function `f` inside the `Interval` or `IntervalBox` `X`.
+"""
+function bisection(f, X::Union{Interval, IntervalBox}; tolerance=1e-3)
 
     image = f(X)
 
-    if 0 ∉ image
-        return Root{T}[]  # guaranteed that no zero in the interval
+    if !(zero(X) ⊆ image)
+        return Root{T}[]
     end
 
     if diam(X) < tolerance

--- a/src/root_finding/bisection.jl
+++ b/src/root_finding/bisection.jl
@@ -1,0 +1,19 @@
+
+function bisection{T}(f, X::Interval{T}; tolerance=1e-3)
+
+    image = f(X)
+
+    if 0 ∉ image
+        return Root{T}[]  # guaranteed that no zero in the interval
+    end
+
+    if diam(X) < tolerance
+        return [Root{T}(X, :unknown)]
+    end
+
+    X1, X2 = bisect(X)
+
+    return [bisection(f, X1, tolerance=tolerance);
+            bisection(f, X2, tolerance=tolerance)]
+
+end

--- a/src/root_finding/bisection.jl
+++ b/src/root_finding/bisection.jl
@@ -4,19 +4,25 @@ doc"""
 
 Find possible roots of the function `f` inside the `Interval` or `IntervalBox` `X`.
 """
-function bisection(f, X::Union{Interval, IntervalBox}; tolerance=1e-3)
+function bisection{T}(f, X::T; tolerance=1e-3, debug=false)
 
     image = f(X)
+
+    debug && @show X, image
 
     if !(zero(X) ⊆ image)
         return Root{T}[]
     end
 
     if diam(X) < tolerance
-        return [Root{T}(X, :unknown)]
+        return [Root(X, :unknown)]
     end
 
     X1, X2 = bisect(X)
+
+    if debug
+        @show X1, X2
+    end
 
     return [bisection(f, X1, tolerance=tolerance);
             bisection(f, X2, tolerance=tolerance)]

--- a/src/root_finding/krawczyk.jl
+++ b/src/root_finding/krawczyk.jl
@@ -66,10 +66,10 @@ function krawczyk{T}(f::Function, f_prime::Function, x::Interval{T}, level::Int=
     # Maximum level of bisection
     level >= maxlevel && return [Root(x, :unknown)]
 
-    isempty(x) && return Root{T}[]  # [(x, :none)]
+    isempty(x) && return Root{typeof(x)}[]  # [(x, :none)]
     Kx = K(f, f_prime, x) ∩ x
 
-    isempty(Kx ∩ x) && return Root{T}[]  # [(x, :none)]
+    isempty(Kx ∩ x) && return Root{typeof(x)}[]  # [(x, :none)]
 
     if Kx ⪽ x  # isinterior
         debug && (print("Refining "); @show(x))

--- a/src/root_finding/newton.jl
+++ b/src/root_finding/newton.jl
@@ -64,7 +64,7 @@ function newton{T}(f::Function, f_prime::Function, x::Interval{T}, level::Int=0;
 
     debug && (print("Entering newton:"); @show(level); @show(x))
 
-    isempty(x) && return Root{T}[]  #[(x, :none)]
+    isempty(x) && return Root{typeof(x)}[]  #[(x, :none)]
 
     z = zero(x.lo)
     tolerance = abs(tolerance)
@@ -79,7 +79,7 @@ function newton{T}(f::Function, f_prime::Function, x::Interval{T}, level::Int=0;
         Nx = N(f, x, deriv)
         debug && @show(Nx, Nx ⊆ x, Nx ∩ x)
 
-        isempty(Nx ∩ x) && return Root{T}[]
+        isempty(Nx ∩ x) && return Root{typeof(x)}[]
 
         if Nx ⊆ x
             debug && (print("Refining "); @show(x))

--- a/src/root_finding/root_finding.jl
+++ b/src/root_finding/root_finding.jl
@@ -21,7 +21,7 @@ const derivative = ForwardDiff.derivative
 const D = derivative
 
 # Root object:
-immutable Root{T}
+immutable Root{T<:Union{Interval,IntervalBox}}
     interval::T
     status::Symbol
 end

--- a/src/root_finding/root_finding.jl
+++ b/src/root_finding/root_finding.jl
@@ -12,6 +12,7 @@ export
     Root, is_unique,
     find_roots,
     find_roots_midpoint,
+    bisection,
     bisect
 
 import Base: ⊆
@@ -19,6 +20,8 @@ import Base: ⊆
 const derivative = ForwardDiff.derivative
 const D = derivative
 
+
+# Root object:
 immutable Root{T<:Real}
     interval::Interval{T}
     status::Symbol
@@ -32,7 +35,26 @@ is_unique{T}(root::Root{T}) = root.status == :unique
 ⊆(a::Root, b::Root) = a.interval ⊆ b.interval
 
 
+# Common functionality:
+
+doc"""Returns the midpoint of the interval x, slightly shifted in case
+the midpoint is an exact root"""
+function guarded_mid{T}(f::Function, x::Interval{T})
+    m = mid(x)
+
+    if f(m) == zero(T)                      # midpoint exactly a root
+        α = convert(T, 0.46875)      # close to 0.5, but exactly representable as a floating point
+        m = α*x.lo + (one(T)-α)*x.hi   # displace to another point in the interval
+    end
+
+    @assert m ∈ x
+
+    return m
+end
+
+
 include("bisect.jl")
+include("bisection.jl")
 include("newton.jl")
 include("krawczyk.jl")
 

--- a/src/root_finding/root_finding.jl
+++ b/src/root_finding/root_finding.jl
@@ -20,10 +20,9 @@ import Base: ⊆
 const derivative = ForwardDiff.derivative
 const D = derivative
 
-
 # Root object:
-immutable Root{T<:Real}
-    interval::Interval{T}
+immutable Root{T}
+    interval::T
     status::Symbol
 end
 

--- a/test/root_finding_tests/bisect.jl
+++ b/test/root_finding_tests/bisect.jl
@@ -2,7 +2,7 @@ using ValidatedNumerics, ValidatedNumerics.RootFinding
 using Base.Test
 
 
-@testset "Bisection tests" begin
+@testset "`bisect` function" begin
     X = 0..1
     @test bisect(X) == (0..0.5, 0.5..1)
     @test bisect(X, 0.25) == (0..0.25, 0.25..1)

--- a/test/root_finding_tests/bisection.jl
+++ b/test/root_finding_tests/bisection.jl
@@ -1,0 +1,34 @@
+using ValidatedNumerics, ValidatedNumerics.RootFinding
+using Base.Test
+
+@testset "Bisection tests" begin
+    @testset "Single variable" begin
+        f(x) = sin(x) + cos(x/2) + x/5
+
+        roots = bisection(f, -∞..∞, tolerance=1e-3)
+        roots2 = [root.interval for root in roots]
+
+        @test roots2 ==  [  Interval(-0.8408203124999999, -0.8398437499999999),
+                            Interval(3.6425781249999996, 3.6435546874999996),
+                            Interval(6.062499999999999, 6.063476562499999)
+                         ]
+
+    end
+
+    @testset "Two variables" begin
+        @intervalbox g(x, y) = (x^2 + y^2 - 1, y - x)
+
+        X = (-∞..∞) × (-∞..∞)
+        roots = bisection(g, X, tolerance=1e-3)
+        roots2 = [root.interval for root in roots]
+        
+        @test roots2 == [IntervalBox(Interval(-0.7080078124999999, -0.7070312499999999), Interval(-0.7080078124999999, -0.7070312499999999)),
+ IntervalBox(Interval(-0.7080078124999999, -0.7070312499999999), Interval(-0.7070312499999999, -0.7060546874999999)),
+ IntervalBox(Interval(-0.7070312499999999, -0.7060546874999999), Interval(-0.7080078124999999, -0.7070312499999999)),
+ IntervalBox(Interval(0.7060546874999999, 0.7070312499999999), Interval(0.7070312499999999, 0.7080078124999999)),
+ IntervalBox(Interval(0.7070312499999999, 0.7080078124999999), Interval(0.7060546874999999, 0.7070312499999999)),
+ IntervalBox(Interval(0.7070312499999999, 0.7080078124999999), Interval(0.7070312499999999, 0.7080078124999999))]
+
+    end
+
+end

--- a/test/root_finding_tests/findroots.jl
+++ b/test/root_finding_tests/findroots.jl
@@ -86,7 +86,7 @@ function_list = [
                                             for i in 1:length(roots)
                                                 root = roots[i]
 
-                                                @test isa(root, Root{prec[1]})
+                                                @test isa(root, Root)
                                                 @test is_unique(root)
                                                 @test true_roots[i] ⊆ root.interval
                                             end


### PR DESCRIPTION
Fixes #204.

This adds a `bisection` root finder that works with single or multiple variables.

Currently, this involves modifying the `Root` type. 
For bisection in particular, this is, in some sense, not necessary, since it cannot prove uniqueness, so any roots are `:unknown`.

However, for multi-dimensional root finding in general, it is maybe necessary to do so.