### PR TITLE
Rename infimum and supremum to inf and sup

### DIFF
--- a/src/ValidatedNumerics.jl
+++ b/src/ValidatedNumerics.jl
@@ -36,7 +36,7 @@ export
     emptyinterval, ∅, ∞, isempty, isinterior, isdisjoint, ⪽,
     precedes, strictprecedes, ≺,
     entireinterval, isentire, nai, isnai, isthin, iscommon,
-    widen, infimum, supremum,
+    widen, inf, sup,
     parameters, eps, dist,
     pi_interval,
     midpoint_radius, interval_from_midpoint_radius,

--- a/src/decorations/functions.jl
+++ b/src/decorations/functions.jl
@@ -33,7 +33,7 @@ in{T<:Real}(x::T, a::DecoratedInterval) = in(x, interval_part(a))
 
 ## scalar functions: mig, mag and friends
 scalar_functions = (
-    :mig, :mag, :infimum, :supremum, :mid, :diam, :radius, :dist, :eps
+    :mig, :mag, :inf, :sup, :mid, :diam, :radius, :dist, :eps
 )
 
 for f in scalar_functions

--- a/src/intervals/arithmetic.jl
+++ b/src/intervals/arithmetic.jl
@@ -226,8 +226,8 @@ end
 
 
 # Infimum and supremum of an interval
-infimum(a::Interval) = a.lo
-supremum(a::Interval) = a.hi
+inf(a::Interval) = a.lo
+sup(a::Interval) = a.hi
 
 
 ## Functions needed for generic linear algebra routines to work

--- a/test/ITF1788_tests/libieeep1788_tests_num.jl
+++ b/test/ITF1788_tests/libieeep1788_tests_num.jl
@@ -31,71 +31,71 @@ setprecision(Interval, Float64)
 # setrounding(Interval, :narrow)
 
 facts("minimal_inf_test") do
-    @fact infimum(∅) --> Inf
-    @fact infimum(Interval(-Inf, Inf)) --> -Inf
-    @fact infimum(Interval(1.0, 2.0)) --> 1.0
-    @fact infimum(Interval(-3.0, -2.0)) --> -3.0
-    @fact infimum(Interval(-Inf, 2.0)) --> -Inf
-    @fact infimum(Interval(-Inf, 0.0)) --> -Inf
-    @fact infimum(Interval(-Inf, -0.0)) --> -Inf
-    @fact infimum(Interval(-2.0, Inf)) --> -2.0
-    @fact infimum(Interval(0.0, Inf)) --> -0.0
-    @fact infimum(Interval(-0.0, Inf)) --> -0.0
-    @fact infimum(Interval(-0.0, 0.0)) --> -0.0
-    @fact infimum(Interval(0.0, -0.0)) --> -0.0
-    @fact infimum(Interval(0.0, 0.0)) --> -0.0
-    @fact infimum(Interval(-0.0, -0.0)) --> -0.0
+    @fact inf(∅) --> Inf
+    @fact inf(Interval(-Inf, Inf)) --> -Inf
+    @fact inf(Interval(1.0, 2.0)) --> 1.0
+    @fact inf(Interval(-3.0, -2.0)) --> -3.0
+    @fact inf(Interval(-Inf, 2.0)) --> -Inf
+    @fact inf(Interval(-Inf, 0.0)) --> -Inf
+    @fact inf(Interval(-Inf, -0.0)) --> -Inf
+    @fact inf(Interval(-2.0, Inf)) --> -2.0
+    @fact inf(Interval(0.0, Inf)) --> -0.0
+    @fact inf(Interval(-0.0, Inf)) --> -0.0
+    @fact inf(Interval(-0.0, 0.0)) --> -0.0
+    @fact inf(Interval(0.0, -0.0)) --> -0.0
+    @fact inf(Interval(0.0, 0.0)) --> -0.0
+    @fact inf(Interval(-0.0, -0.0)) --> -0.0
 end
 
 facts("minimal_inf_dec_test") do
-    @fact infimum(DecoratedInterval(∅, trv)) --> Inf
-    @fact infimum(DecoratedInterval(Interval(-Inf, Inf), def)) --> -Inf
-    @fact infimum(DecoratedInterval(Interval(1.0, 2.0), com)) --> 1.0
-    @fact infimum(DecoratedInterval(Interval(-3.0, -2.0), trv)) --> -3.0
-    @fact infimum(DecoratedInterval(Interval(-Inf, 2.0), dac)) --> -Inf
-    @fact infimum(DecoratedInterval(Interval(-Inf, 0.0), def)) --> -Inf
-    @fact infimum(DecoratedInterval(Interval(-Inf, -0.0), trv)) --> -Inf
-    @fact infimum(DecoratedInterval(Interval(-2.0, Inf), trv)) --> -2.0
-    @fact infimum(DecoratedInterval(Interval(0.0, Inf), def)) --> -0.0
-    @fact infimum(DecoratedInterval(Interval(-0.0, Inf), trv)) --> -0.0
-    @fact infimum(DecoratedInterval(Interval(-0.0, 0.0), dac)) --> -0.0
-    @fact infimum(DecoratedInterval(Interval(0.0, -0.0), trv)) --> -0.0
-    @fact infimum(DecoratedInterval(Interval(0.0, 0.0), trv)) --> -0.0
-    @fact infimum(DecoratedInterval(Interval(-0.0, -0.0), trv)) --> -0.0
+    @fact inf(DecoratedInterval(∅, trv)) --> Inf
+    @fact inf(DecoratedInterval(Interval(-Inf, Inf), def)) --> -Inf
+    @fact inf(DecoratedInterval(Interval(1.0, 2.0), com)) --> 1.0
+    @fact inf(DecoratedInterval(Interval(-3.0, -2.0), trv)) --> -3.0
+    @fact inf(DecoratedInterval(Interval(-Inf, 2.0), dac)) --> -Inf
+    @fact inf(DecoratedInterval(Interval(-Inf, 0.0), def)) --> -Inf
+    @fact inf(DecoratedInterval(Interval(-Inf, -0.0), trv)) --> -Inf
+    @fact inf(DecoratedInterval(Interval(-2.0, Inf), trv)) --> -2.0
+    @fact inf(DecoratedInterval(Interval(0.0, Inf), def)) --> -0.0
+    @fact inf(DecoratedInterval(Interval(-0.0, Inf), trv)) --> -0.0
+    @fact inf(DecoratedInterval(Interval(-0.0, 0.0), dac)) --> -0.0
+    @fact inf(DecoratedInterval(Interval(0.0, -0.0), trv)) --> -0.0
+    @fact inf(DecoratedInterval(Interval(0.0, 0.0), trv)) --> -0.0
+    @fact inf(DecoratedInterval(Interval(-0.0, -0.0), trv)) --> -0.0
 end
 
 facts("minimal_sup_test") do
-    @fact supremum(∅) --> -Inf
-    @fact supremum(Interval(-Inf, Inf)) --> Inf
-    @fact supremum(Interval(1.0, 2.0)) --> 2.0
-    @fact supremum(Interval(-3.0, -2.0)) --> -2.0
-    @fact supremum(Interval(-Inf, 2.0)) --> 2.0
-    @fact supremum(Interval(-Inf, 0.0)) --> 0.0
-    @fact supremum(Interval(-Inf, -0.0)) --> 0.0
-    @fact supremum(Interval(-2.0, Inf)) --> Inf
-    @fact supremum(Interval(0.0, Inf)) --> Inf
-    @fact supremum(Interval(-0.0, Inf)) --> Inf
-    @fact supremum(Interval(-0.0, 0.0)) --> 0.0
-    @fact supremum(Interval(0.0, -0.0)) --> 0.0
-    @fact supremum(Interval(0.0, 0.0)) --> 0.0
-    @fact supremum(Interval(-0.0, -0.0)) --> 0.0
+    @fact sup(∅) --> -Inf
+    @fact sup(Interval(-Inf, Inf)) --> Inf
+    @fact sup(Interval(1.0, 2.0)) --> 2.0
+    @fact sup(Interval(-3.0, -2.0)) --> -2.0
+    @fact sup(Interval(-Inf, 2.0)) --> 2.0
+    @fact sup(Interval(-Inf, 0.0)) --> 0.0
+    @fact sup(Interval(-Inf, -0.0)) --> 0.0
+    @fact sup(Interval(-2.0, Inf)) --> Inf
+    @fact sup(Interval(0.0, Inf)) --> Inf
+    @fact sup(Interval(-0.0, Inf)) --> Inf
+    @fact sup(Interval(-0.0, 0.0)) --> 0.0
+    @fact sup(Interval(0.0, -0.0)) --> 0.0
+    @fact sup(Interval(0.0, 0.0)) --> 0.0
+    @fact sup(Interval(-0.0, -0.0)) --> 0.0
 end
 
 facts("minimal_sup_dec_test") do
-    @fact supremum(DecoratedInterval(∅, trv)) --> -Inf
-    @fact supremum(DecoratedInterval(Interval(-Inf, Inf), def)) --> Inf
-    @fact supremum(DecoratedInterval(Interval(1.0, 2.0), com)) --> 2.0
-    @fact supremum(DecoratedInterval(Interval(-3.0, -2.0), trv)) --> -2.0
-    @fact supremum(DecoratedInterval(Interval(-Inf, 2.0), dac)) --> 2.0
-    @fact supremum(DecoratedInterval(Interval(-Inf, 0.0), def)) --> 0.0
-    @fact supremum(DecoratedInterval(Interval(-Inf, -0.0), trv)) --> 0.0
-    @fact supremum(DecoratedInterval(Interval(-2.0, Inf), trv)) --> Inf
-    @fact supremum(DecoratedInterval(Interval(0.0, Inf), def)) --> Inf
-    @fact supremum(DecoratedInterval(Interval(-0.0, Inf), trv)) --> Inf
-    @fact supremum(DecoratedInterval(Interval(-0.0, 0.0), dac)) --> +0.0
-    @fact supremum(DecoratedInterval(Interval(0.0, -0.0), trv)) --> +0.0
-    @fact supremum(DecoratedInterval(Interval(0.0, 0.0), trv)) --> +0.0
-    @fact supremum(DecoratedInterval(Interval(-0.0, -0.0), trv)) --> +0.0
+    @fact sup(DecoratedInterval(∅, trv)) --> -Inf
+    @fact sup(DecoratedInterval(Interval(-Inf, Inf), def)) --> Inf
+    @fact sup(DecoratedInterval(Interval(1.0, 2.0), com)) --> 2.0
+    @fact sup(DecoratedInterval(Interval(-3.0, -2.0), trv)) --> -2.0
+    @fact sup(DecoratedInterval(Interval(-Inf, 2.0), dac)) --> 2.0
+    @fact sup(DecoratedInterval(Interval(-Inf, 0.0), def)) --> 0.0
+    @fact sup(DecoratedInterval(Interval(-Inf, -0.0), trv)) --> 0.0
+    @fact sup(DecoratedInterval(Interval(-2.0, Inf), trv)) --> Inf
+    @fact sup(DecoratedInterval(Interval(0.0, Inf), def)) --> Inf
+    @fact sup(DecoratedInterval(Interval(-0.0, Inf), trv)) --> Inf
+    @fact sup(DecoratedInterval(Interval(-0.0, 0.0), dac)) --> +0.0
+    @fact sup(DecoratedInterval(Interval(0.0, -0.0), trv)) --> +0.0
+    @fact sup(DecoratedInterval(Interval(0.0, 0.0), trv)) --> +0.0
+    @fact sup(DecoratedInterval(Interval(-0.0, -0.0), trv)) --> +0.0
 end
 
 facts("minimal_mid_test") do

--- a/test/interval_tests/consistency.jl
+++ b/test/interval_tests/consistency.jl
@@ -150,13 +150,13 @@ c = @interval(0.25, 4.0)
         @test isnai(nai())
         @test !(isnai(a))
 
-        @test infimum(a) == a.lo
-        @test supremum(a) == a.hi
-        @test infimum(emptyinterval(a)) == Inf
-        @test supremum(emptyinterval(a)) == -Inf
-        @test infimum(entireinterval(a)) == -Inf
-        @test supremum(entireinterval(a)) == Inf
-        @test isnan(supremum(nai(BigFloat)))
+        @test inf(a) == a.lo
+        @test sup(a) == a.hi
+        @test inf(emptyinterval(a)) == Inf
+        @test sup(emptyinterval(a)) == -Inf
+        @test inf(entireinterval(a)) == -Inf
+        @test sup(entireinterval(a)) == Inf
+        @test isnan(sup(nai(BigFloat)))
     end
 
     @testset "mid" begin


### PR DESCRIPTION
Fixes #252.

Rename `infinimum`->`inf`; `supremum`->`sup`.