### PR TITLE
Reworked compat, CRLibm 1.0 was breaking ValidatedNumerics

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ repo = "https://github.com/JuliaIntervals/ValidatedNumerics.jl.git"
 version = "0.12.0"
 
 [deps]
+CRlibm = "96374032-68de-5a5b-8d9e-752f78720389"
 IntervalArithmetic = "d1acc4aa-44c8-5952-acd4-ba5d80a2a253"
 IntervalConstraintProgramming = "138f1668-1576-5ad7-91b9-7425abbf3153"
 IntervalContractors = "15111844-de3b-5229-b4ba-526f2f385dc9"
@@ -13,14 +14,15 @@ Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 TaylorModels = "314ce334-5f6e-57ae-acf6-00b6e903104a"
 
 [compat]
-IntervalArithmetic = "0.16, 0.17, 0.18"
-IntervalRootFinding = "0.5"
-IntervalContractors = "0.4"
-IntervalConstraintProgramming = "0.12"
-IntervalOptimisation = "0.4"
-TaylorModels = "0.3"
+IntervalArithmetic = ">=0.16"
+IntervalConstraintProgramming = ">=0.12"
+IntervalContractors = ">=0.4"
+IntervalOptimisation = ">=0.4"
+IntervalRootFinding = ">=0.5"
 Reexport = "0.2, 1.0"
-julia = "1.3, 1.4, 1.5, 1.6"
+TaylorModels = ">=0.3"
+julia = ">=1.3"
+CRlibm = "1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
The latest version of CRlibm, that forces IntervalArithmetic > 0.18 is breaking ValidatedNumerics, i.e., there is no installable version of IntervalArithmetic. I think CRlibm should be added as a dependence to ValidatedNumerics and the [compat] section should be treated accordingly.